### PR TITLE
Add metric name to outfile

### DIFF
--- a/lm_eval/base.py
+++ b/lm_eval/base.py
@@ -62,10 +62,11 @@ class Task(ABC):
     @abstractmethod
     def process_results(self, generations, references):
         """Takes the list of LM generations and evaluates them against ground truth references,
-        returning the metric for the generations.
+        returning the metric for the generations as in {"metric_name": result}.
         :param generations: list(list(str))
             list of lists containing generations
         :param references: list(str)
             list of str containing refrences
+        :return: dict[str: float]
         """
         pass

--- a/lm_eval/tasks/codexglue_code_to_text.py
+++ b/lm_eval/tasks/codexglue_code_to_text.py
@@ -197,7 +197,7 @@ class GeneralCodeToText(Task):
         bleu_score = compute_codexglue_code_to_text_bleu(
             (ref, gen[0]) for ref, gen in zip(references, generations)
         )
-        return bleu_score
+        return {"blue": bleu_score}
 
 
 class LeftCodeToText(GeneralCodeToText):

--- a/lm_eval/tasks/conala.py
+++ b/lm_eval/tasks/conala.py
@@ -10,9 +10,10 @@ Here we use two-shot evaluation (the original paper evaluates finetuned models)
 """
 
 import json
-from evaluate import load
-from lm_eval.base import Task
 
+from evaluate import load
+
+from lm_eval.base import Task
 
 _CITATION = """
 @inproceedings{yin2018learning,
@@ -60,7 +61,9 @@ class Conala(Task):
                    \nSolution:\n{examples['solution2']}\
                    \nInstruction:\n{text}\
                    \nSolution:\n"
-        assert prompt.count("Solution:\n") == 3, "Splitting operation in postprocess_generation is invalid"
+        assert (
+            prompt.count("Solution:\n") == 3
+        ), "Splitting operation in postprocess_generation is invalid"
         return entry + prompt
 
     def get_prompt(self, doc):

--- a/lm_eval/tasks/conala.py
+++ b/lm_eval/tasks/conala.py
@@ -100,4 +100,4 @@ class Conala(Task):
         results = bleu.compute(
             references=references, predictions=gens, max_order=4, smooth=True
         )["bleu"]
-        return results
+        return {"bleu": results}

--- a/lm_eval/tasks/conala.py
+++ b/lm_eval/tasks/conala.py
@@ -102,5 +102,5 @@ class Conala(Task):
         gens = [gen[0] for gen in generations]
         results = bleu.compute(
             references=references, predictions=gens, max_order=4, smooth=True
-        )["bleu"]
-        return {"bleu": results}
+        )
+        return results

--- a/lm_eval/tasks/concode.py
+++ b/lm_eval/tasks/concode.py
@@ -103,5 +103,5 @@ class Concode(Task):
         gens = [gen[0] for gen in generations]
         results = bleu.compute(
             references=references, predictions=gens, max_order=4, smooth=True
-        )["bleu"]
-        return {"bleu": results}
+        )
+        return results

--- a/lm_eval/tasks/concode.py
+++ b/lm_eval/tasks/concode.py
@@ -11,9 +11,10 @@ Available at https://huggingface.co/datasets/code_x_glue_ct_code_to_text
 Here we use two-shot evaluation (the original paper evaluates finetuned models)
 """
 import json
-from evaluate import load
-from lm_eval.base import Task
 
+from evaluate import load
+
+from lm_eval.base import Task
 
 _CITATION = """
 @article{iyer2018mapping,
@@ -50,7 +51,7 @@ class Concode(Task):
         ) as file:
             examples = json.load(file)
         return examples
-    
+
     @staticmethod
     def two_shot_prompt(entry, text, examples):
         """Two shot prompt format as instructions & solutions"""
@@ -60,7 +61,9 @@ class Concode(Task):
                    \nSolution:\n{examples['solution2']}\
                    \nInstruction:\n{text}\
                    \nSolution:\n"
-        assert prompt.count("Solution:\n") == 3, "Splitting operation in postprocess_generation is invalid"
+        assert (
+            prompt.count("Solution:\n") == 3
+        ), "Splitting operation in postprocess_generation is invalid"
         return entry + prompt
 
     def get_prompt(self, doc):

--- a/lm_eval/tasks/concode.py
+++ b/lm_eval/tasks/concode.py
@@ -101,4 +101,4 @@ class Concode(Task):
         results = bleu.compute(
             references=references, predictions=gens, max_order=4, smooth=True
         )["bleu"]
-        return results
+        return {"bleu": results}

--- a/templates/new_task.py
+++ b/templates/new_task.py
@@ -79,7 +79,7 @@ class NewTask(Task):
         # generations and reference solutions
         """
         Takes the list of LM generations and evaluates them against ground truth references,
-        returning the metric for the generations.
+        returning the metric for the generations as in {"metric_name": result}.
         We encourage to directly load the metric from `evaluate` library to keep the code concise.
         :param generations: list(list(str))
             list of lists containing generations

--- a/templates/new_task.py
+++ b/templates/new_task.py
@@ -9,7 +9,6 @@ Homepage: TODO: Add the URL to the task's Homepage here.
 """
 from lm_eval.base import Task
 
-
 # TODO: Add the BibTeX citation for the task.
 _CITATION = """
 """


### PR DESCRIPTION
Issue https://github.com/bigcode-project/bigcode-evaluation-harness/issues/24
Changed docstring of `postprocess_results` to require output to be a `dict` indicating metric name
This is needed for BLEU tasks, but code_eval already outputs pass@k which is the correct metric name. 

<img width="269" alt="pass@1 0 0" src="https://user-images.githubusercontent.com/44069155/208252390-85acfd5a-b61a-4349-9656-120ae25aae9a.png">

<img width="280" alt="Pasted Graphic 1" src="https://user-images.githubusercontent.com/44069155/208252395-3433c6f8-9769-4242-ab53-2680f11c1008.png">
