### PR TITLE
Fix number of copies per task when nsamples  is not proportional to batch size

### DIFF
--- a/lm_eval/evaluator.py
+++ b/lm_eval/evaluator.py
@@ -52,6 +52,11 @@ class Evaluator:
             args=self.args,
         )
         references = [task.get_reference(dataset[i]) for i in range(n_tasks)]
+        if len(generations[0]) > self.args.n_samples:
+            generations = [l[: self.args.n_samples] for l in generations]
+            warnings.warn(
+                f"Number of tasks wasn't proportional to number of devices, we removed extra predictions to only keep nsamples={self.args.n_samples}"
+            )
         return generations, references
 
     def evaluate(self, task_name):
@@ -60,11 +65,6 @@ class Evaluator:
             raise ValueError(_WARNING)
 
         generations, references = self.generate_text(task_name)
-        if len(generations[0]) != self.args.n_samples:
-            generations = [l[: self.args.n_samples] for l in generations]
-            warnings.warn(
-                "Number of tasks wasn't proportional to number of devices, we removed extra predictions"
-            )
 
         if self.accelerator.is_main_process:
             if not self.args.generations_path:

--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -1,5 +1,6 @@
 from tqdm import tqdm
 import json
+from math import ceil
 
 from torch.utils.data.dataloader import DataLoader
 from transformers import StoppingCriteria, StoppingCriteriaList
@@ -62,7 +63,7 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
 
     if accelerator.is_main_process:
         print(f"number of problems for this task is {n_tasks}")
-    n_copies = args.n_samples // args.batch_size
+    n_copies = ceil(args.n_samples / args.batch_size)
 
     ds_tokenized = TokenizedDataset(
         task,


### PR DESCRIPTION
If the batch size is not proportional to `nsamples` the previous formula `ncopies = nsamples // batch_size` would generate an insufficient number of copies per task to reach `nsamples` (issue #48 ). We use `ceil` instead and delete extra completions. 