### PR TITLE
remove model from accelerate prepare and add precision argument

### DIFF
--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -78,8 +78,12 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
 
     # do not confuse args.batch_size, which is actually the num_return_sequences
     ds_loader = DataLoader(ds_tokenized, batch_size=1)
-
-    model, ds_loader = accelerator.prepare(model, ds_loader)
+    if args.precision =="bf16":
+        print("Converting model to bf16")
+        model = model.bfloat16().cuda()
+    else:
+        model = model.cuda()
+    ds_loader = accelerator.prepare(ds_loader)
     generations = complete_code(
         task,
         accelerator,

--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -78,14 +78,16 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
 
     # do not confuse args.batch_size, which is actually the num_return_sequences
     ds_loader = DataLoader(ds_tokenized, batch_size=1)
+
+    device = accelerator.device
     if args.precision == "bf16":
         print("Converting model to bf16")
-        model = model.bfloat16().cuda()
+        model = model.bfloat16().to(device)
     elif args.precision == "fp16":
         print("Converting model to fp16")
-        model = model.half().cuda()
+        model = model.half().to(device)
     else:
-        model = model.cuda()
+        model = model.to(device)
 
     ds_loader = accelerator.prepare(ds_loader)
     generations = complete_code(

--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -81,8 +81,12 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
     if args.precision =="bf16":
         print("Converting model to bf16")
         model = model.bfloat16().cuda()
+    elif args.precision == "fp16":
+        print("Converting model to fp16")
+        model = model.bfloat16().cuda()   
     else:
         model = model.cuda()
+    
     ds_loader = accelerator.prepare(ds_loader)
     generations = complete_code(
         task,

--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -78,18 +78,9 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
 
     # do not confuse args.batch_size, which is actually the num_return_sequences
     ds_loader = DataLoader(ds_tokenized, batch_size=1)
-
-    device = accelerator.device
-    if args.precision == "bf16":
-        print("Converting model to bf16")
-        model = model.bfloat16().to(device)
-    elif args.precision == "fp16":
-        print("Converting model to fp16")
-        model = model.half().to(device)
-    else:
-        model = model.to(device)
-
+    model = model.to(accelerator.device)
     ds_loader = accelerator.prepare(ds_loader)
+
     generations = complete_code(
         task,
         accelerator,

--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -1,10 +1,10 @@
-from tqdm import tqdm
 import json
 from math import ceil
 
-from torch.utils.data.dataloader import DataLoader
-from transformers import StoppingCriteria, StoppingCriteriaList
 from accelerate.utils import set_seed
+from torch.utils.data.dataloader import DataLoader
+from tqdm import tqdm
+from transformers import StoppingCriteria, StoppingCriteriaList
 
 from lm_eval.utils import TokenizedDataset, complete_code
 
@@ -78,15 +78,15 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
 
     # do not confuse args.batch_size, which is actually the num_return_sequences
     ds_loader = DataLoader(ds_tokenized, batch_size=1)
-    if args.precision =="bf16":
+    if args.precision == "bf16":
         print("Converting model to bf16")
         model = model.bfloat16().cuda()
     elif args.precision == "fp16":
         print("Converting model to fp16")
-        model = model.bfloat16().cuda()   
+        model = model.half().cuda()
     else:
         model = model.cuda()
-    
+
     ds_loader = accelerator.prepare(ds_loader)
     generations = complete_code(
         task,

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -125,7 +125,9 @@ def complete_code(
         with torch.no_grad():
             if task.stop_words:
                 # Set the start_length after which to check for stopping to be the longest input ignoring padding
-                gen_kwargs["stopping_criteria"][0].start_length = batch["input_len"].max().item()
+                gen_kwargs["stopping_criteria"][0].start_length = (
+                    batch["input_len"].max().item()
+                )
             generated_tokens = model.generate(
                 input_ids=batch["ids"][:, : batch["input_len"]],
                 num_return_sequences=batch_size,

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -126,7 +126,7 @@ def complete_code(
             if task.stop_words:
                 # Set the start_length after which to check for stopping to be the longest input ignoring padding
                 gen_kwargs["stopping_criteria"][0].start_length = batch["input_len"].max().item()
-            generated_tokens = accelerator.unwrap_model(model).generate(
+            generated_tokens = model.generate(
                 input_ids=batch["ids"][:, : batch["input_len"]],
                 num_return_sequences=batch_size,
                 **gen_kwargs,

--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ def parse_args():
         "--precision",
         type=str,
         default=None,
-        help="Model precision: bf16, fp16 or None",
+        help="Model precision, from: bf16, fp16 or None",
     )
     parser.add_argument(
         "--generations_path",

--- a/main.py
+++ b/main.py
@@ -91,6 +91,12 @@ def parse_args():
         help="Do code generation but no evaluation",
     )
     parser.add_argument(
+        "--precision",
+        type=str,
+        default=None,
+        help="Model precision: bf16, fp16 or None",
+    )
+    parser.add_argument(
         "--generations_path",
         type=str,
         default=None,

--- a/tests/test_generation_evaluation.py
+++ b/tests/test_generation_evaluation.py
@@ -44,6 +44,7 @@ def update_args(args):
     args.top_p = 0
     args.n_samples = 1
     args.seed = 0
+    args.precision = ""
     return args
 
 


### PR DESCRIPTION
Passing both model and dataloader to `accelerate.prepare` takes unnecessary memory as noticed by @RaymondLi0, which causes OOM for large models.
This is because the model  is wrapped in the `DistributedDataParallel` class which will reserve memory for the gradients for training ([issue](https://github.com/huggingface/accelerate/issues/1336)).  We now only wrap the dataloader, and we also add `precision` argument to properly load model in bf16 or fp16. (the mixed-precison `accelerate` argument in config is for mixed precision in training and will load two model copies..)

Todo: add cpu case