### PR TITLE
update humaneval postprocessing

### DIFF
--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -57,6 +57,8 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         "max_length": args.max_length_generation,
     }
     if task.stop_words:
+        if tokenizer.eos_token:
+            task.stop_words.append(tokenizer.eos_token)
         gen_kwargs["stopping_criteria"] = StoppingCriteriaList(
             [EndOfFunctionCriteria(0, task.stop_words, tokenizer)]
         )

--- a/lm_eval/tasks/humaneval.py
+++ b/lm_eval/tasks/humaneval.py
@@ -77,6 +77,7 @@ class HumanEval(Task):
             (not used for Humaneval-Task)
         """
         prompt = self.get_prompt(self.dataset["test"][idx])
+        generation = generation[len(prompt) :]
         return prompt + self._stop_at_stop_token(generation, self.stop_words)
 
     def process_results(self, generations, references):

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -176,6 +176,10 @@ def complete_code(
                     ),
                     tokenizer,
                 )
+            elif tokenizer.eos_token in task.stop_words:
+                gen_code = tokenizer.decode(
+                    s, skip_special_tokens=False, clean_up_tokenization_spaces=False
+                )
             else:
                 gen_code = tokenizer.decode(
                     s, skip_special_tokens=True, clean_up_tokenization_spaces=True


### PR DESCRIPTION
As highlighted in issue https://github.com/bigcode-project/bigcode-evaluation-harness/issues/46 it's possible to have more than one stop word in the code completion and keeping only last black might leave intermediate functions for example. Normally we have the [stopping criteria](https://github.com/bigcode-project/bigcode-evaluation-harness/blob/f21de320a36aeb841dd49a43524af6c40e995416/lm_eval/generation.py#L12) that stops generation once there's a stop word, but when `batch_size>1`  it's done on all batch and generation stops only when all of them have seen a stop word.

This doesn't seems to have a noticeable impact on performance though especially pass@1 and pass@10.


EDIT: another fix, following this [discussion](https://github.com/bigcode-project/bigcode-evaluation-harness/pull/47#discussion_r1173650483) with @Muennighoff he noticed that the `eos_token` is being skipped during the decoding and this can lead to generations with unwanted extra text when `batch_size > 1`. Thanks for the fix!