### PR TITLE
added FIM tokens for bigcode/large-model

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -93,6 +93,8 @@ class TokenizedDataset(IterableDataset):
             return f"{prefix}<|mask:0|>{suffix}<|mask:0|>"
         elif model_id in ["bigcode/santacoder"]:
             return f"<fim-prefix>{prefix}<fim-suffix>{suffix}<fim-middle>"
+        elif model_id in ["bigcode/large-model"]:
+            return f"<fim_prefix>{prefix}<fim_suffix>{suffix}<fim_middle>"
         else:
             raise ValueError(f"Infilling not yet supported for: {model_id}")
 
@@ -157,6 +159,10 @@ def complete_code(
         elif model_id in ["bigcode/santacoder"]:
             prefix, rest = code.split("<fim-suffix>", 1)
             suffix, infill = rest.split("<fim-middle>", 1)
+            infill = infill.split("<|endoftext|>")[0]
+        elif model_id in ["bigcode/large-model"]:
+            prefix, rest = code.split("<fim_suffix>", 1)
+            suffix, infill = rest.split("<fim_middle>", 1)
             infill = infill.split("<|endoftext|>")[0]
         else:
             raise ValueError(f"Infilling not yet supported for: {model_id}")


### PR DESCRIPTION
`bigcode/large-model` uses slightly different FIM tokens than `bigcode/santacoder`. I've integrated these into the eval harness and am currently running the `DS1000` benchmark in `insertion` mode which appears to be working based on partial results so far.