### PR TITLE
prepend and parse prefix cli arg correctly when doing FIM

### DIFF
--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -162,7 +162,7 @@ def complete_code(
             prefix, rest = code.split("<fim-suffix>", 1)
             suffix, infill = rest.split("<fim-middle>", 1)
             infill = infill.split("<|endoftext|>")[0]
-        elif model_id in ["bigcode/large-model", "bigcode/temp-model"]:
+        elif model_id in ["bigcode/starcoder", "bigcode/starcoderbase"]:
             prefix, rest = code.split("<fim_suffix>", 1)
             suffix, infill = rest.split("<fim_middle>", 1)
             infill = infill.split("<|endoftext|>")[0]

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -95,7 +95,7 @@ class TokenizedDataset(IterableDataset):
             return f"{preprefix}{prefix}<|mask:0|>{suffix}<|mask:0|>"
         elif model_id in ["bigcode/santacoder"]:
             return f"<fim-prefix>{preprefix}{prefix}<fim-suffix>{suffix}<fim-middle>"
-        elif model_id in ["bigcode/large-model", "bigcode/temp-model"]:
+        elif model_id in ["bigcode/starcoder", "bigcode/starcoderbase"]:
             return f"<fim_prefix>{preprefix}{prefix}<fim_suffix>{suffix}<fim_middle>"
         else:
             raise ValueError(f"Infilling not yet supported for: {model_id}")


### PR DESCRIPTION
When invoking the `--prefix` arg from the CLI, this was prepended to the FIM prompt. This works fine for models like `incoder`, which don't explicitly define FIM mode with a token at the start of the prompt, but with the `bigcode` models, it leads to weird behavior. I've adjusted such that the CLI prefix arg is prepended before the FIM prefix code but after the `<fim_prefix>` special token. This results in comparable accuracy on DS-1000 with and without `--prefix` being specified at the CLI.