### PR TITLE
add trust_remote_code to tokenizer loading

### DIFF
--- a/main.py
+++ b/main.py
@@ -183,6 +183,7 @@ def main():
         tokenizer = AutoTokenizer.from_pretrained(
             args.model,
             revision=args.revision,
+            trust_remote_code=args.trust_remote_code,
             use_auth_token=args.use_auth_token,
             truncation_side="left",
         )


### PR DESCRIPTION
some tokenizers require running local code hence the need for trust_remote_code argument