### PR TITLE
Support 8bit and 4bit inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We use [`accelerate`](https://huggingface.co/docs/accelerate/index) to generate 
 accelerate config
 ```
 
-This evaluation harness can also be used in an evaluation only mode, you can use a Multi-CPU setting. For large models, we recommend specifying the precision of the model using the `--precision` flag instead of accelerate config to have only one copy of the model in memory.
+This evaluation harness can also be used in an evaluation only mode, you can use a Multi-CPU setting. For large models, we recommend specifying the precision of the model using the `--precision` flag instead of accelerate config to have only one copy of the model in memory. You can also load models in 8bit with the flag `--load_in_8bit` if you have `bitsandbytes` installed.
 
 The evaluation part (solutions execution) for [MultiPL-E](https://github.com/nuprl/MultiPL-E) requires extra dependencies for some programming languages, we provide a Dockerfile with all dependencies, see section [Docker](#docker-containers) for more details.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We use [`accelerate`](https://huggingface.co/docs/accelerate/index) to generate 
 accelerate config
 ```
 
-This evaluation harness can also be used in an evaluation only mode, you can use a Multi-CPU setting. For large models, we recommend specifying the precision of the model using the `--precision` flag instead of accelerate config to have only one copy of the model in memory. You can also load models in 8bit with the flag `--load_in_8bit` or 4bit with `--load_in_4bit` if you have `bitsandbytes` installed with required transformers and accelerate versions..
+This evaluation harness can also be used in an evaluation only mode, you can use a Multi-CPU setting. For large models, we recommend specifying the precision of the model using the `--precision` flag instead of accelerate config to have only one copy of the model in memory. You can also load models in 8bit with the flag `--load_in_8bit` or 4bit with `--load_in_4bit` if you have `bitsandbytes` installed with the required transformers and accelerate versions.
 
 The evaluation part (solutions execution) for [MultiPL-E](https://github.com/nuprl/MultiPL-E) requires extra dependencies for some programming languages, we provide a Dockerfile with all dependencies, see section [Docker](#docker-containers) for more details.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ We use [`accelerate`](https://huggingface.co/docs/accelerate/index) to generate 
 accelerate config
 ```
 
-This evaluation harness can also be used in an evaluation only mode, you can use a Multi-CPU setting. For large models, we recommend specifying the precision of the model using the `--precision` flag instead of accelerate config to have only one copy of the model in memory. You can also load models in 8bit with the flag `--load_in_8bit` if you have `bitsandbytes` installed.
+This evaluation harness can also be used in an evaluation only mode, you can use a Multi-CPU setting. For large models, we recommend specifying the precision of the model using the `--precision` flag instead of accelerate config to have only one copy of the model in memory. You can also load models in 8bit with the flag `--load_in_8bit` or 4bit with `--load_in_4bit` if you have `bitsandbytes` installed with required transformers and accelerate versions..
 
 The evaluation part (solutions execution) for [MultiPL-E](https://github.com/nuprl/MultiPL-E) requires extra dependencies for some programming languages, we provide a Dockerfile with all dependencies, see section [Docker](#docker-containers) for more details.
 

--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -91,8 +91,14 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
 
     # do not confuse args.batch_size, which is actually the num_return_sequences
     ds_loader = DataLoader(ds_tokenized, batch_size=1)
-    model = model.to(accelerator.device)
-    ds_loader = accelerator.prepare(ds_loader)
+    is_loaded_in_8bit = getattr(model, "is_loaded_in_8bit", False)
+    if not is_loaded_in_8bit:
+        # we only wrap data loader to avoid extra memory occupation
+        model = model.to(accelerator.device)
+        ds_loader = accelerator.prepare(ds_loader)
+    else:
+        # model.to() is not supported for 8bit models
+        model, ds_loader = accelerator.prepare(model, ds_loader)
 
     generations = complete_code(
         task,
@@ -105,6 +111,7 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         prefix=args.prefix,
         instruction_tokens=instruction_tokens,
         postprocess=args.postprocess,
+        is_loaded_in_8bit=is_loaded_in_8bit,
         **gen_kwargs,
     )
     return generations

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -199,7 +199,7 @@ def complete_code(
     prefix="",
     instruction_tokens=None,
     postprocess=True,
-    is_loaded_in_8bit=False,
+    is_wrapped=False,
     **gen_kwargs,
 ):
     """Generate multiple codes for each task in the dataset using multiple GPUs with accelerate.
@@ -222,8 +222,8 @@ def complete_code(
                     batch["input_len"].max().item()
                 )
             inputs = batch["ids"][:, : batch["input_len"]]
-            if is_loaded_in_8bit:
-                # 8bit models are wrapped in accelerator
+            if is_wrapped:
+                # 8bit and 4bit models are wrapped in accelerator
                 generated_tokens = accelerator.unwrap_model(model).generate(
                     input_ids=inputs,
                     num_return_sequences=batch_size,

--- a/main.py
+++ b/main.py
@@ -87,6 +87,11 @@ def parse_args():
         help="Load model in 8bit",
     )
     parser.add_argument(
+        "--load_in_4bit",
+        action="store_true",
+        help="Load model in 4bit",
+    )
+    parser.add_argument(
         "--limit",
         type=int,
         default=None,
@@ -192,11 +197,22 @@ def main():
                 load_in_8bit=args.load_in_8bit,
                 trust_remote_code=args.trust_remote_code,
                 use_auth_token=args.use_auth_token,
-                device_map={'': current_device},
+                device_map={"": current_device},
             )
-
+        elif args.load_in_4bit:
+            print("Loading model in 4bit")
+            current_device = accelerator.process_index
+            # the model needs to fit in one GPU
+            model = AutoModelForCausalLM.from_pretrained(
+                args.model,
+                revision=args.revision,
+                load_in_4bit=args.load_in_4bit,
+                trust_remote_code=args.trust_remote_code,
+                use_auth_token=args.use_auth_token,
+                device_map={"": current_device},
+            )
         else:
-            print(f"Loading model (in {args.precision})")
+            print(f"Loading model in {args.precision}")
             model = AutoModelForCausalLM.from_pretrained(
                 args.model,
                 revision=args.revision,


### PR DESCRIPTION
This PR adds a `--load_in_8bit` and `--load_in_4bit` flags and support 8bit  and 4bit models inference. Addresses https://github.com/bigcode-project/bigcode-evaluation-harness/issues/91 (although SantaCoder has known [issues](https://github.com/bigcode-project/bigcode-evaluation-harness/issues/83) with inference in fp16, and as a consequence it also does in 8bit -in particular with top-p sampling, greedy seems to work fine- outside the scope of this PR)

Tested on StarCoder for HumanEval with
```
accelerate launch  main.py   --model bigcode/starcoder   --max_length_generation 512  --tasks humaneval   --n_samples 20   --batch_size 20   --temperature 0.2    --allow_code_execution   --use_auth_token --load_in_8bit
```
And it seems to work properly on 4 GPUs
```
{
  "humaneval": {
    "pass@1": 0.3371951219512195,
    "pass@10": 0.5014858423687616
  },
  "config": {
    "model": "bigcode/starcoder",
    "revision": null,
    "temperature": 0.2,
    "n_samples": 20
  }
}
```
`load_in_4bit` gives `"pass@1": 0.35243902439024394` for the same parameters
(users need to have `bitsandbytes` installed)
