### PR TITLE
Update MultiPL-E prompts

### DIFF
--- a/lm_eval/tasks/multiple.py
+++ b/lm_eval/tasks/multiple.py
@@ -80,7 +80,7 @@ class GeneralMultiPLE(Task):
 
     DATASET_PATH = "nuprl/MultiPL-E"
     DATASET_NAME = None
-    DATASET_REVISION = "5d2abbb8ced9a0e37db985c47d24c24f45a16655"
+    DATASET_REVISION = "d23b094346c5dbda1080a74bb2a24c18adbf7409"
 
     def __init__(self, language):
         self.language = language


### PR DESCRIPTION
This patch updates the version of MultiPL-E used in the evaluation harness to the version that was used in the StarCoder paper. The previous version were the prompts used for the SantaCoder paper.

For the StarCoder paper, we fixed a number of bugs that were artificially lowering the scores for a couple of languages -- almost all typed languages. Most notable is that Java's performance will go up about 2-3% on StarCoderBase with this update.