### PR TITLE
[WIP] adding ShaderEval tasks

### DIFF
--- a/lm_eval/tasks/ShaderEval.py
+++ b/lm_eval/tasks/ShaderEval.py
@@ -1,0 +1,94 @@
+# This template file is adapted from: https://github.com/EleutherAI/lm-evaluation-harness/blob/master/templates/new_task.py
+
+# TODO: Remove all TODO comments once the implementation is complete.
+"""
+Paper-Title: Throwing Shaders at Language Models - Evaluating Creative Code Generation
+TODO: Paper-URL: unavailable (unpublished)
+Description: ShaderEval aims to be a suite of tasks to evaluate generative model on creative code generation. Espeicically GLSL shadercode.
+    Task1 is a proof of concept and looks at code completion for returnstatemetns of Shadertoy functions. Exact_match and greedy decoding.
+Homepage: https://huggingface.co/spaces/Vipitis/ShaderEval
+"""
+from lm_eval.base import Task
+import evaluate
+
+# TODO: Add the BibTeX citation for the task.
+_CITATION = """tbd
+"""
+
+
+# TODO: Replace `NewTask` with the name of your Task.
+class ShaderEval_task1(Task):
+    # TODO: Add the `DATASET_PATH` string. This will be the name of the `Task`
+    # dataset as denoted in HuggingFace `datasets`.
+    DATASET_PATH = "Vipitis/Shadertoys-fine"
+    # TODO: Add the `DATASET_NAME` string. This is the name of a subset within
+    # `DATASET_PATH`. If there aren't specific subsets you need, leave this as `None`.
+    DATASET_NAME = "return_completion"
+
+    def __init__(self):
+        super().__init__(
+            # TODO: Specify the list of stop words in `stop_words` for the code generation task \
+            # and if the evaluation requires executing the generated code in `requires_execution`.
+            stop_words=[";"],
+            requires_execution=False,
+        )
+
+    def get_dataset(self):
+        # TODO: retrieve the evaluation subset from the loaded dataset (e.g. `self.dataset["test"]`)
+        """Returns dataset for the task or an iterable of any object, that get_prompt can handle"""
+        return self.dataset["test"]
+
+    def fewshot_examples(self):
+        # TODO: load few-shot examples (from lm_eval/tasks/fewshot_examples) if they exist
+        """Loads and returns the few-shot examples for the task if they exist."""
+        pass
+
+    def get_prompt(self, doc):
+        # TODO: build the prompt for the language model from a sample `doc` from the dataset
+        """
+        Builds the prompt for the LM to generate from.
+        :param doc: dict[str: str]
+            sample from the test dataset
+        :return: str
+        """
+        return doc["body"]
+
+    def get_reference(self, doc):
+        # TODO: get the reference solution from a sample `doc` from the dataset
+        """
+        Builds the reference solution for the doc (sample from the test dataset).
+        :param doc: dict[str: str]
+            sample from the test dataset
+        :return: str
+        """
+        return doc["return_statement"].split(";")[0].strip()
+
+    def postprocess_generation(self, generation, idx):
+        # TODO: define the postprocessing for the LM generation
+        """
+        Defines the postprocessing for a LM generation.
+        :param generation: str
+            code generation from LM
+        :param idx: int (if needed)
+            index of doc in the dataset to which the generation belongs
+        :return: str
+        """
+        generation = generation.split("return")[1] #this works?
+        return generation.split(";")[0].strip()
+
+    def process_results(self, generations, references):
+        # TODO: define how the evaluation score is computed from list of \
+        # generations and reference solutions
+        """
+        Takes the list of LM generations and evaluates them against ground truth references,
+        returning the metric for the generations as in {"metric_name": result}.
+        We encourage to directly load the metric from `evaluate` library to keep the code concise.
+        :param generations: list(list(str))
+            list of lists containing generations
+        :param references: list(str)
+            list of str containing refrences
+        :return: dict[str: float]
+        """
+        exact_match = evaluate.load("exact_match")
+        generations = [generation[0] for generation in generations] #unpack one list for some reason? (we zero shot)
+        return exact_match.compute(predictions=generations, references=references)

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -1,7 +1,7 @@
 from pprint import pprint
 
 from . import (apps, codexglue_code_to_text, codexglue_text_to_text, conala,
-               concode, ds1000, gsm, humaneval, mbpp, multiple, instruct_humaneval, ShaderEval)
+               concode, ds1000, gsm, humaneval, mbpp, multiple, instruct_humaneval, shadereval)
 
 TASK_REGISTRY = {
     **apps.create_all_tasks(),
@@ -16,7 +16,7 @@ TASK_REGISTRY = {
     "mbpp": mbpp.MBPP,
     **gsm.create_all_tasks(),
     **instruct_humaneval.create_all_tasks(),
-    "ShaderEval": ShaderEval.ShaderEval_task1,
+    "shadereval": shadereval.ReturnCompletion,
 }
 
 ALL_TASKS = sorted(list(TASK_REGISTRY))

--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -1,7 +1,7 @@
 from pprint import pprint
 
 from . import (apps, codexglue_code_to_text, codexglue_text_to_text, conala,
-               concode, ds1000, gsm, humaneval, mbpp, multiple, instruct_humaneval)
+               concode, ds1000, gsm, humaneval, mbpp, multiple, instruct_humaneval, ShaderEval)
 
 TASK_REGISTRY = {
     **apps.create_all_tasks(),
@@ -16,6 +16,7 @@ TASK_REGISTRY = {
     "mbpp": mbpp.MBPP,
     **gsm.create_all_tasks(),
     **instruct_humaneval.create_all_tasks(),
+    "ShaderEval": ShaderEval.ShaderEval_task1,
 }
 
 ALL_TASKS = sorted(list(TASK_REGISTRY))

--- a/lm_eval/tasks/shadereval.py
+++ b/lm_eval/tasks/shadereval.py
@@ -17,7 +17,7 @@ _CITATION = """tbd
 
 
 # TODO: Replace `NewTask` with the name of your Task.
-class ShaderEval_task1(Task):
+class ReturnCompletion(Task): #Task1
     # TODO: Add the `DATASET_PATH` string. This will be the name of the `Task`
     # dataset as denoted in HuggingFace `datasets`.
     DATASET_PATH = "Vipitis/Shadertoys-fine"
@@ -73,7 +73,7 @@ class ShaderEval_task1(Task):
             index of doc in the dataset to which the generation belongs
         :return: str
         """
-        generation = generation.split("return")[1] #this works?
+        generation = generation.split("return")[1]  # this works?
         return generation.split(";")[0].strip()
 
     def process_results(self, generations, references):
@@ -90,5 +90,7 @@ class ShaderEval_task1(Task):
         :return: dict[str: float]
         """
         exact_match = evaluate.load("exact_match")
-        generations = [generation[0] for generation in generations] #unpack one list for some reason? (we zero shot)
+        generations = [
+            generation[0] for generation in generations
+        ]  # unpack one list for some reason? (we zero shot)
         return exact_match.compute(predictions=generations, references=references)


### PR DESCRIPTION
Hey, first PR for me here:

adding ShaderEval task1, this is essentially just implementing the task as is in the [EvaluationSuite](https://huggingface.co/spaces/Vipitis/ShaderEval): return completion.
the task is very much just meant as a "proof of concept" as there are several issues with it. I do plan on introducing more tasks to this benchmark soon and also make them generally better.
I do have several question too.

some differences that should not impact the results:
- generation returns the prompt, so we remove it again in `postprocess_generation`
- stop word is set as `";"` - not the list of all tokens containing the semicolon (does the `EndOfFunctionCriteria` handle this?)
- generation parameters can't be set so user has to set `--do_sample False` to use greedy search (temperature can't be set to 0?)

concerns I hope to address:
- my term paper on the project isn't yet published so I got no reference to explain the tasks
- my naming convention doesn't seem to fit
- I did not add any documentation yet
- fix the dataset revision to 0.0.2 for this task specifically
- I had to comment out all `import fcntl` as that module does not exist on my home machine (Windows), so running tests wasn't possible
- It's really slow on my home machine (as Intel GPU is not supported in accelerate on Windows), therefore I have only been able to run a few models with really short snippets. I got matching scores for `gpt2`, `bigscience/bloom-560m` and `Vipitis/santacoder-finetuned-Shadertoys-fine` when running just 10 samples. Additionally I did a single run with 300 samples (this snippet is used throughout the paper) and got matching numbers of 0.566
Run parameters were the following:
```bash
accelerate launch main.py \
  --model Vipitis/santacoder-finetuned-Shadertoys-fine \
  --tasks ShaderEval \
  --limit 10 \
  --do_sample False \ 
  --save_generations \
  --save_generations_path generations_py.json \
  --use_auth_token \
  --trust_remote_code
``` 
(not having the last two doesn't throw any error but still runs (even slower) and return erroneous outputs)