### PR TITLE
Adding additional optional arguments for decoding flags and AutoModel kwargs to support models like ReplitLM

### DIFF
--- a/lm_eval/generation.py
+++ b/lm_eval/generation.py
@@ -113,6 +113,7 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         instruction_tokens=instruction_tokens,
         postprocess=args.postprocess,
         is_wrapped=is_loaded_in_8bit or is_loaded_in_4bit,
+        clean_up_tokenization_spaces=args.clean_up_tokenization_spaces,
         **gen_kwargs,
     )
     return generations

--- a/lm_eval/utils.py
+++ b/lm_eval/utils.py
@@ -200,6 +200,7 @@ def complete_code(
     instruction_tokens=None,
     postprocess=True,
     is_wrapped=False,
+    clean_up_tokenization_spaces=True,
     **gen_kwargs,
 ):
     """Generate multiple codes for each task in the dataset using multiple GPUs with accelerate.
@@ -257,7 +258,7 @@ def complete_code(
                 if s[0] == tokenizer.bos_token_id:
                     s = s[1:]
                 gen_code = tokenizer.decode(
-                    s, skip_special_tokens=False, clean_up_tokenization_spaces=False
+                    s, skip_special_tokens=False, clean_up_tokenization_spaces=clean_up_tokenization_spaces
                 )
                 if INFILL_MODE:
                     gen_code = _parse_infill(gen_code, tokenizer)
@@ -265,7 +266,7 @@ def complete_code(
                     gen_code = _parse_instruction(gen_code, instruction_tokens)
             else:
                 gen_code = tokenizer.decode(
-                    s, skip_special_tokens=True, clean_up_tokenization_spaces=True
+                    s, skip_special_tokens=True, clean_up_tokenization_spaces=clean_up_tokenization_spaces
                 )
             if not INFILL_MODE:
                 gen_code = gen_code[len(prefix) :]

--- a/main.py
+++ b/main.py
@@ -148,7 +148,7 @@ def parse_args():
     parser.add_argument(
         "--automodel_kwargs",
         type=json.loads,
-        default=None,
+        default='{}',
         help="Keyword arguments to pass to AutoModelForCausalLM",
     )
 

--- a/main.py
+++ b/main.py
@@ -103,6 +103,11 @@ def parse_args():
         help="Postprocess model outputs before execution, always on except during generation tests",
     )
     parser.add_argument(
+        "--clean_up_tokenization_spaces",
+        action="store_false",
+        help="Set the clean_up_tokenization_spaces in tokenizer.decode() to False for specific models, defaults to True",
+    )
+    parser.add_argument(
         "--allow_code_execution",
         action="store_true",
         help="Allow code evaluation to execute external/untrusted Python code on your machine",
@@ -140,6 +145,13 @@ def parse_args():
         action="store_true",
         help="Whether to save reference solutions/tests",
     )
+    parser.add_argument(
+        "--automodel_kwargs",
+        type=json.loads,
+        default=None,
+        help="Keyword arguments to pass to AutoModelForCausalLM",
+    )
+
     return parser.parse_args()
 
 
@@ -198,6 +210,7 @@ def main():
                 trust_remote_code=args.trust_remote_code,
                 use_auth_token=args.use_auth_token,
                 device_map={"": current_device},
+                **args.automodel_kwargs,
             )
         elif args.load_in_4bit:
             print("Loading model in 4bit")
@@ -210,6 +223,7 @@ def main():
                 trust_remote_code=args.trust_remote_code,
                 use_auth_token=args.use_auth_token,
                 device_map={"": current_device},
+                **args.automodel_kwargs,
             )
         else:
             print(f"Loading model in {args.precision}")
@@ -219,6 +233,7 @@ def main():
                 torch_dtype=dict_precisions[args.precision],
                 trust_remote_code=args.trust_remote_code,
                 use_auth_token=args.use_auth_token,
+                **args.automodel_kwargs,
             )
 
         tokenizer = AutoTokenizer.from_pretrained(

--- a/main.py
+++ b/main.py
@@ -148,7 +148,7 @@ def parse_args():
     parser.add_argument(
         "--automodel_kwargs",
         type=json.loads,
-        default='{}',
+        default="{}",
         help="Keyword arguments to pass to AutoModelForCausalLM",
     )
 


### PR DESCRIPTION
Why
===

In line with this project's aim, we want to support more models such as ReplitLM for transparent result reproduction for the community!

For that, we require the ability to configure the `tokenizer.decode` call, as well as model args in the `AutoModelForCausalLM.from_pretrained` to be able to reproduce results. 

What changed
============

We add two input arguments with safe default behaviour to the `main.py` script:
1. `clean_up_tokenization_spaces` : `bool`
-  this boolean flag is passed to `tokenizer.decode` to prevent tokenization spaces from being cleaned up.  This flag affects spacing and therefore syntax in generated code with certain tokenizers such as the ReplitLM tokenizer.
- defaults to `True`, stores `False`


2. `automodel_kwargs`: `json.loads`, aka. a "stringified" JSON
-  a "stringified" JSON that sets what default config values should be overriden in this harness to reproduce results. 
- updates default init config key-values by being passed into the `AutoModelForCausalLM.from_pretrained` as `kwargs`. See the logic of why and how this works [here](https://huggingface.co/docs/transformers/v4.30.0/en/model_doc/auto#transformers.TFAutoModel.from_pretrained.kwargs) in the `transformers` documentation. 
- defaults to empty stringified JSON: `"{}"`. 

[x] This is fully backward and forward compatible
