### PR TITLE
Update stop tokens for mbpp and humaneval

### DIFF
--- a/lm_eval/tasks/humaneval.py
+++ b/lm_eval/tasks/humaneval.py
@@ -35,7 +35,7 @@ class HumanEval(Task):
 
     def __init__(self):
         super().__init__(
-            stop_words=["\nclass", "\ndef", "\n#", "\n@", "\nprint", "\nif"],
+            stop_words=["\nclass", "\ndef", "\n#", "\n@", "\nprint", "\nif", "\n```"],
             requires_execution=True,
         )
 

--- a/lm_eval/tasks/mbpp.py
+++ b/lm_eval/tasks/mbpp.py
@@ -35,7 +35,7 @@ class MBPP(Task):
 
     def __init__(self):
         super().__init__(
-            stop_words=["\nclass", "\nassert", '\n"""', "\nprint", "\nif", "\n<|/"],
+            stop_words=["\nclass", "\nassert", '\n"""', "\nprint", "\nif", "\n<|/", "\n```"],
             requires_execution=True,
         )
 


### PR DESCRIPTION
When training a model on markdown/notebook data, the model can output backticks after a code block.  This will cause the code to not run, even though the solution might be valid.

This updates the mpbb and humaneval stop tokens to account for this behavior.