### PR TITLE
Add  WizardCoder models (that are CodeLLama based) evaluation

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -1,24 +1,10 @@
 import inspect
 from pprint import pprint
 
-from . import (
-    apps,
-    codexglue_code_to_text,
-    codexglue_text_to_text,
-    conala,
-    concode,
-    ds1000,
-    gsm,
-    humaneval,
-    humanevalpack,
-    instruct_humaneval,
-    mbpp,
-    multiple,
-    parity,
-    python_bugs,
-    quixbugs,
-    recode,
-)
+from . import (apps, codexglue_code_to_text, codexglue_text_to_text, conala,
+               concode, ds1000, gsm, humaneval, humanevalpack,
+               instruct_humaneval, instruct_wizard_humaneval, mbpp, multiple,
+               parity, python_bugs, quixbugs, recode)
 
 TASK_REGISTRY = {
     **apps.create_all_tasks(),
@@ -35,6 +21,7 @@ TASK_REGISTRY = {
     "parity": parity.Parity,
     "python_bugs": python_bugs.PythonBugs,
     "quixbugs": quixbugs.QuixBugs,
+    "instruct_wizard_humaneval": instruct_wizard_humaneval.HumanEvalWizardCoder,
     **gsm.create_all_tasks(),
     **instruct_humaneval.create_all_tasks(),
     **recode.create_all_tasks(),

--- a/lm_eval/tasks/instruct_wizard_humaneval.py
+++ b/lm_eval/tasks/instruct_wizard_humaneval.py
@@ -1,0 +1,124 @@
+"""Instruction version of HumanEval used for WizardCoder Models evaluation
+Evaluating Large Language Models Trained on Code
+https://arxiv.org/abs/2107.03374
+
+The HumanEval dataset released by OpenAI includes 164 programming problems with a function signature,
+docstring, body, and several unit tests. 
+They were handwritten to ensure not to be included in the training set of code generation models.
+
+Homepage: https://github.com/openai/human-eval
+"""
+
+import re
+
+from evaluate import load
+
+from lm_eval.base import Task
+
+_CITATION = """
+@misc{chen2021evaluating,
+      title={Evaluating Large Language Models Trained on Code},
+      author={Mark Chen and Jerry Tworek and Heewoo Jun and Qiming Yuan and Henrique Ponde de Oliveira Pinto and Jared Kaplan and Harri Edwards and Yuri Burda and Nicholas Joseph and Greg Brockman and Alex Ray and Raul Puri and Gretchen Krueger and Michael Petrov and Heidy Khlaaf and Girish Sastry and Pamela Mishkin and Brooke Chan and Scott Gray and Nick Ryder and Mikhail Pavlov and Alethea Power and Lukasz Kaiser and Mohammad Bavarian and Clemens Winter and Philippe Tillet and Felipe Petroski Such and Dave Cummings and Matthias Plappert and Fotios Chantzis and Elizabeth Barnes and Ariel Herbert-Voss and William Hebgen Guss and Alex Nichol and Alex Paino and Nikolas Tezak and Jie Tang and Igor Babuschkin and Suchir Balaji and Shantanu Jain and William Saunders and Christopher Hesse and Andrew N. Carr and Jan Leike and Josh Achiam and Vedant Misra and Evan Morikawa and Alec Radford and Matthew Knight and Miles Brundage and Mira Murati and Katie Mayer and Peter Welinder and Bob McGrew and Dario Amodei and Sam McCandlish and Ilya Sutskever and Wojciech Zaremba},
+      year={2021},
+      eprint={2107.03374},
+      archivePrefix={arXiv},
+      primaryClass={cs.LG}
+}
+"""
+
+
+def generate_prompt(input):
+    INSTRUCTION = f"""Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+
+### Instruction:
+Create a Python script for this problem:
+{input}
+
+### Response:"""
+    return INSTRUCTION
+
+
+class HumanEvalWizardCoder(Task):
+    """A task represents an entire benchmark including its dataset, problems,
+    answers, generation settings and evaluation methods.
+    """
+
+    DATASET_PATH = "openai_humaneval"
+
+    def __init__(self):
+
+        super().__init__(
+            stop_words=[],
+            requires_execution=True,
+        )
+
+    def get_dataset(self):
+        """Returns dataset for the task or an iterable of any object, that get_prompt can handle"""
+        return self.dataset["test"]
+
+    def get_prompt(self, doc):
+        """Builds the prompt for the LM to generate from."""
+        prompt = doc["prompt"].replace("    ", "\t")
+        prompt = generate_prompt(prompt)
+        return prompt
+
+    def get_reference(self, doc):
+        """Builds the reference solution for the doc (sample from the test dataset)."""
+        test_func = doc["test"]
+        entry_point = f"check({doc['entry_point']})"
+        return "\n" + test_func + "\n" + entry_point
+
+    @staticmethod
+    def clean_comp(completion):
+        # adapted from https://github.com/nlpxucan/WizardLM/blob/main/WizardCoder/src/process_humaneval.py
+        if "```python" in completion:
+            def_line = completion.index("```python")
+            completion = completion[def_line:].strip()
+            completion = completion.replace("```python", "")
+            try:
+                next_line = completion.index("```")
+                completion = completion[:next_line].strip()
+            except:
+                a += 1
+        if '__name__ == "__main__"' in completion:
+            next_line = completion.index('if __name__ == "__main__":')
+            completion = completion[:next_line].strip()
+
+        if "# Example usage" in completion:
+            next_line = completion.index("# Example usage")
+            completion = completion[:next_line].strip()
+        if completion.startswith("Here's"):
+            completion = completion.split("\n")[1:]
+            completion = "\n".join(completion)
+        result = completion
+        return result
+
+    def postprocess_generation(self, generation, idx):
+        """Defines the postprocessing for a LM generation.
+        :param generation: str
+            code generation from LM
+        :param idx: int
+            index of doc in the dataset to which the generation belongs
+            (not used for Humaneval-Task)
+        """
+        generation = generation.split("### Response:")[-1]
+        generation = generation.replace("\t", "    ")
+        generation = generation.split("</s>")[0]
+        generation = self.clean_comp(generation)
+        return generation
+
+    def process_results(self, generations, references):
+        """Takes the list of LM generations and evaluates them against ground truth references,
+        returning the metric for the generations.
+        :param generations: list(list(str))
+            list of lists containing generations
+        :param references: list(str)
+            list of str containing refrences
+        """
+        code_metric = load("code_eval")
+        results, _ = code_metric.compute(
+            references=references,
+            predictions=generations,
+        )
+        return results

--- a/main.py
+++ b/main.py
@@ -289,10 +289,21 @@ def main():
                 raise ValueError("No eos_token or bos_token found")
         try:
             tokenizer.pad_token = tokenizer.eos_token
+            
         # Some models like CodeGeeX2 have pad_token as a read-only property
         except AttributeError:
             print("Not setting pad_token to eos_token")
             pass
+        WIZARD_LLAMA_MODELS = [
+            "WizardLM/WizardCoder-Python-34B-V1.0",
+            "WizardLM/WizardCoder-34B-V1.0",
+            "WizardLM/WizardCoder-Python-13B-V1.0"
+        ]
+        if args.model in WIZARD_LLAMA_MODELS:
+            tokenizer.bos_token = "<s>"
+            tokenizer.bos_token_id = 1
+            print("Changing bos_token to <s>")
+
         evaluator = Evaluator(accelerator, model, tokenizer, args)
 
         for task in task_names:


### PR DESCRIPTION
- The WizardCoder models (starting from CodeLlama) now add `<s>` token at the beginning of tokenized text but have `bos_token` set at `</s>` which impacts the [post-processing](https://github.com/bigcode-project/bigcode-evaluation-harness/blob/484614ca3fb252423dfd93896f0e642c72c7b4c4/lm_eval/utils.py#L313C1-L313C1) (see [issue](https://huggingface.co/WizardLM/WizardCoder-Python-34B-V1.0/discussions/15))
- We add evaluation using the same prompt and post-processing (an Instruction version of HumanEval slightly different from HumanEvalSynthesize) as the original authors [here](https://github.com/nlpxucan/WizardLM/blob/main/WizardCoder/src/humaneval_gen_vllm.py) (could be moved to HumanEvalPack task later)