### PR TITLE
Add --save_references_path into args

### DIFF
--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -84,9 +84,9 @@ class Evaluator:
                             f"generations were saved at {self.args.save_generations_path}"
                         )
                 if self.args.save_references:
-                    with open("references.json", "w") as fp:
+                    with open(self.args.save_references_path, "w") as fp:
                         json.dump(references, fp)
-                        print("references were saved at references.json")
+                        print(f"references were saved at {self.args.save_references_path}")
 
             # make sure tokenizer plays nice with multiprocessing
             os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/main.py
+++ b/main.py
@@ -170,6 +170,12 @@ def parse_args():
         help="Whether to save reference solutions/tests",
     )
     parser.add_argument(
+        "--save_references_path",
+        type=str,
+        default="references.json",
+        help="Path for saving the references solutions/tests",
+    )
+    parser.add_argument(
         "--prompt",
         type=str,
         default="prompt",
@@ -335,9 +341,9 @@ def main():
                         json.dump(generations, fp)
                         print(f"generations were saved at {args.save_generations_path}")
                     if args.save_references:
-                        with open("references.json", "w") as fp:
+                        with open(args.save_references_path, "w") as fp:
                             json.dump(references, fp)
-                            print("references were saved")
+                            print(f"references were saved at {args.save_references_path}")
             else:
                 results[task] = evaluator.evaluate(task)
 

--- a/tests/test_generation_evaluation.py
+++ b/tests/test_generation_evaluation.py
@@ -31,6 +31,7 @@ def update_args(args):
     args.save_generations = False
     args.save_generations_path = ""
     args.save_references = False
+    args.save_references_path = ""
     args.metric_output_path = TMPDIR
     args.load_generations_path = None
     args.generation_only = False


### PR DESCRIPTION
Arguments like `--save_generations` `--save_generations_path` `--save_references` exists, but `--save_references_path` misses. We can add it and it does not affect existing code.