### PR TITLE
Dockerfile-multiple no longer fetches pip dependencies needlessly

### DIFF
--- a/Dockerfile-multiple
+++ b/Dockerfile-multiple
@@ -48,9 +48,10 @@ RUN mkdir /usr/multiple && wget https://repo.mavenlibs.com/maven/org/javatuples/
 RUN apt-get update -yqq && apt-get install -yqq lua-unit
 
 # Standard requirements
-COPY . /app
 WORKDIR /app
+COPY ./requirements.txt /app/requirements.txt
+RUN pip3 install -r requirements.txt
+COPY . /app
 RUN test -f /app/generations.json && rm /app/generations.json || true
 
-RUN pip3 install .
 CMD ["python3", "main.py"]


### PR DESCRIPTION
Whilst developing a custom task using the Dockerfile-multiple rebuilding the Dockerfile while editing the python code also forced pip to install all dependencies again. So instead of copying the complete code path we first copy the requirements and install them using pip.

This now gives us the benefit that Docker will cache this intermediate image and only when we change the requirements.txt a rebuild is triggered. So development speed that relies on the Dockerfile-multiple is increased dramatically.