### PR TITLE
Add support for Ollama, Palm, Claude-2, Cohere, Replicate, Llama2 CodeLlama (100+LLMs) [LiteLLM]

### DIFF
--- a/bigcode_eval/tasks/humanevalpack_openai.py
+++ b/bigcode_eval/tasks/humanevalpack_openai.py
@@ -37,6 +37,7 @@ messages=messages
 
 import os
 import openai
+import litellm
 import jsonlines
 import termcolor
 
@@ -170,7 +171,7 @@ class ChatWrapper:
         ]
         while True:
             try:
-                response = openai.ChatCompletion.create(
+                response = litellm.completion(
                     model=self._model,
                     messages=messages,
                     temperature=0.2,
@@ -199,8 +200,8 @@ if __name__ == '__main__':
         with jsonlines.open(f"completions_{LANGUAGE}_humanevalexplaindescribe.jsonl", "r") as f:
             descriptions = [line["raw_generation"][0] for line in f]
 
-    openai.organization = os.getenv("OPENAI_ORGANIZATION")
-    openai.api_key = os.getenv("OPENAI_API_KEY")
+    litellm.organization = os.getenv("OPENAI_ORGANIZATION")
+    litellm.api_key = os.getenv("OPENAI_API_KEY")
 
     samples = [s for s in load_dataset("bigcode/humanevalpack", LANGUAGE)["test"]]
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ ds1000_requirements = [
     "matplotlib==3.5.2",
     "numpy==1.21.6",
     "openai==0.23.0",
+    "litellm==0.13.2",
     "pandas==1.3.5",
     "pandas-datareader==0.10.0",
     "pathlib==1.0.1",


### PR DESCRIPTION
This PR adds support for the above mentioned LLMs using LiteLLM https://github.com/BerriAI/litellm/ 
LiteLLM is a lightweight package to simplify LLM API calls - use any llm as a drop in replacement for gpt-3.5-turbo. 

Example
```python
from litellm import completion

## set ENV variables
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion(model="command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```