### PR TITLE
QOL changes for generations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
-          pip install transformers==4.21.1 accelerate==0.13.2 datasets==2.6.1 evaluate==0.2.2 pyext==0.7 mosestokenizer==1.0.0 "fsspec<2023.10.0"
+          pip install transformers==4.21.1 accelerate==0.13.2 datasets==2.14.6 evaluate==0.2.2 pyext==0.7 mosestokenizer==1.0.0 "fsspec<2023.10.0"
       #- name: Lint with flake8
       #  run: |
       #    flake8 .

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -44,7 +44,8 @@ class Evaluator:
         task = tasks.get_task(task_name, self.args)
         dataset = task.get_dataset()
         # if args.limit is None, use all samples
-        n_tasks = self.args.limit if self.args.limit else len(dataset)
+        # if args.limit is used, make sure args.limit_start + args.limit <= len(dataset)
+        n_tasks = min(self.args.limit, len(dataset) - self.args.limit_start) if self.args.limit else len(dataset)
         # when args.limit is None
         # adjust n_tasks by args.limit_start to prevent out of bounds issues 
         if not self.args.limit:

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -59,14 +59,14 @@ class Evaluator:
                 solutions = [[ref] for ref in references]
             return solutions, references
 
-        generations = []  # list[list[str | None] | None]
+        curr_generations = []  # list[list[str | None] | None]
         if intermediate_generations:
-            generations = [gen for gen in intermediate_generations if gen]
-            n_tasks -= len(generations)
+            curr_generations = [gen for gen in intermediate_generations if gen]
+            n_tasks -= len(curr_generations)
         intermediate_save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}_intermediate.json"
-        curr_sample_idx = len(generations)
+        curr_sample_idx = len(curr_generations)
 
-        new_generations = parallel_generations(
+        generations = parallel_generations(
             task,
             dataset,
             self.accelerator,
@@ -76,10 +76,9 @@ class Evaluator:
             args=self.args,
             curr_sample_idx=curr_sample_idx,  # curr_sample_idx will added to limit_start to fix indexing
             save_every_k_tasks=self.args.save_every_k_tasks,
-            intermediate_generations=generations,
+            intermediate_generations=curr_generations,
             intermediate_save_generations_path=intermediate_save_generations_path,
         )
-        generations.extend(new_generations)
 
         if len(generations[0]) > self.args.n_samples:
             generations = [l[: self.args.n_samples] for l in generations]

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -28,25 +28,6 @@ Once you have read this disclaimer and taken appropriate precautions, set the ar
 ################################################################################\
 """
 
-def chunk_list(item_list: List[Any], chunk_size: int = 32) -> List[List[Any]]:
-    """
-    Turn an list of items into a list of item chunks
-    Where each chunk is at most of len `chunk_size`
-
-    Args:
-        item_list (List[Any]): an list of items to batchify
-        chunk_size (int): the size of each chunk
-
-    Returns:
-        a List[List[Any]] where each List[Any] is of at most length chunk_size
-        and the length of the list is ceiling(len(item_list)/chunk_size)
-    """
-    if chunk_size < 1:
-        raise ValueError("chunk_size must be >= 1")
-    if len(item_list) == 0:
-        raise ValueError("Must be a non-empty list")
-    return [item_list[i : i + chunk_size] for i in range(0, len(item_list), chunk_size)]
-
 class Evaluator:
     def __init__(self, accelerator, model, tokenizer, args):
         self.accelerator = accelerator
@@ -61,7 +42,7 @@ class Evaluator:
         self.allow_code_execution = args.allow_code_execution
 
     # TODO (Max): add in the passed list of generations to start from an intermediate checkpoint
-    def generate_text(self, task_name):
+    def generate_text(self, task_name):  # TODO (Max): pass intermediate generations file here
         task = tasks.get_task(task_name, self.args)
         dataset = task.get_dataset()
         # if args.limit is None, use all samples
@@ -75,41 +56,28 @@ class Evaluator:
                 solutions = [[ref] for ref in references]
             return solutions, references
 
-        generations = []
-
-        # TODO (Max): if intermediate generations file is passed
-        # Then append all the generations from that task to `generations`
-        # and only chunk data from generations onward
-        # Note: ALSO want to change `parallel_generations` so that we don't use self.args.limit_start if curr_iter isn't 0
-                # chunk data for saving intermediate generations and references
-        chunk_size = self.args.save_every_k_samples if self.args.save_every_k_samples >= 1 else len(references)
-        dataset_chunks = chunk_list(dataset, chunk_size)
+        generations = []  # list[list[str | None]] (list of a list of generations)
+        # Note (Max): when passing an intermediate list of generations, the len would be the same as n_tasks
+        # so need to subset by 
+        # generations = [gen for gen in loaded_generations if len(gen) > 0] or [gen for gen in loaded_generations if gen]
         
         intermediate_save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}_intermediate.json"
 
-        for iter, data_chunk in enumerate(dataset_chunks):
-            curr_sample_idx = len(generations)  
-            generation_chunk = parallel_generations(
-                task,
-                Dataset.from_dict(data_chunk),
-                self.accelerator,
-                self.model,
-                self.tokenizer,
-                n_tasks=n_tasks,
-                args=self.args,
-                curr_iter=iter,  # Note: this is because we manually change limit_start to 0 if curr_iter > 0
-                curr_sample_idx=curr_sample_idx,  # curr_sample_idx will be used in `complete_code` so we don't mess up indexing during post-process
-            )
-            generations.extend(generation_chunk)
+        curr_sample_idx = len(generations)  
+        generation_chunk = parallel_generations(
+            task,
+            dataset,
+            self.accelerator,
+            self.model,
+            self.tokenizer,
+            n_tasks=n_tasks,
+            args=self.args,
+            curr_sample_idx=curr_sample_idx,  # curr_sample_idx will added to limit_start to fix indexing
+            save_every_k_samples = self.args.save_every_k_samples,
+            intermediate_save_generations_path=intermediate_save_generations_path
+        )
+        generations.extend(generation_chunk)
 
-            # save intermediate results
-            if self.accelerator.is_main_process:
-                self.save_json_files(
-                    generations,
-                    references[:len(generations)],
-                    intermediate_save_generations_path,
-                    f"references_{task_name}_intermediate.json"
-                )
 
         if len(generations[0]) > self.args.n_samples:
             generations = [l[: self.args.n_samples] for l in generations]
@@ -118,7 +86,7 @@ class Evaluator:
             )
         return generations, references
 
-    def evaluate(self, task_name):
+    def evaluate(self, task_name):  # TODO (Max): pass intermediate generations file here
         task = tasks.get_task(task_name, self.args)
         if task.requires_execution and not self.allow_code_execution:
             raise ValueError(_WARNING)
@@ -128,7 +96,7 @@ class Evaluator:
         if self.accelerator.is_main_process:
             if not self.args.load_generations_path:
                 save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}.json"
-                self.save_json_files(generations, references, save_generations_path, f"references_{task_name}.json")
+                self.save_json_files(self.args, generations, references, save_generations_path, f"references_{task_name}.json")
 
             # make sure tokenizer plays nice with multiprocessing
             os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -75,6 +75,7 @@ class Evaluator:
             args=self.args,
             curr_sample_idx=curr_sample_idx,  # curr_sample_idx will added to limit_start to fix indexing
             save_every_k_tasks=self.args.save_every_k_tasks,
+            intermediate_generations=generations,
             intermediate_save_generations_path=intermediate_save_generations_path,
         )
         generations.extend(new_generations)

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -74,7 +74,7 @@ class Evaluator:
             n_tasks=n_tasks,
             args=self.args,
             curr_sample_idx=curr_sample_idx,  # curr_sample_idx will added to limit_start to fix indexing
-            save_every_k_samples=self.args.save_every_k_samples,
+            save_every_k_tasks=self.args.save_every_k_tasks,
             intermediate_save_generations_path=intermediate_save_generations_path,
         )
         generations.extend(new_generations)

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -40,7 +40,7 @@ class Evaluator:
         # code evaluation permission
         self.allow_code_execution = args.allow_code_execution
 
-    def generate_text(self, task_name, intermediate_generations):
+    def generate_text(self, task_name, intermediate_generations=None):
         task = tasks.get_task(task_name, self.args)
         dataset = task.get_dataset()
         # if args.limit is None, use all samples
@@ -86,12 +86,12 @@ class Evaluator:
             )
         return generations, references
 
-    def evaluate(self, task_name, intermediate_generations):
+    def evaluate(self, task_name, intermediate_generations=None):
         task = tasks.get_task(task_name, self.args)
         if task.requires_execution and not self.allow_code_execution:
             raise ValueError(_WARNING)
 
-        generations, references = self.generate_text(task_name, intermediate_generations)
+        generations, references = self.generate_text(task_name, intermediate_generations=intermediate_generations)
 
         if self.accelerator.is_main_process:
             if not self.args.load_generations_path:

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -3,9 +3,8 @@ import json
 import os
 import warnings
 
-from typing import Any, Iterable, List
+from typing import List
 
-from datasets import Dataset
 
 from bigcode_eval import tasks
 from bigcode_eval.generation import parallel_generations
@@ -41,8 +40,7 @@ class Evaluator:
         # code evaluation permission
         self.allow_code_execution = args.allow_code_execution
 
-    # TODO (Max): add in the passed list of generations to start from an intermediate checkpoint
-    def generate_text(self, task_name, intermediate_generations):  # TODO (Max): pass intermediate generations file here
+    def generate_text(self, task_name, intermediate_generations):
         task = tasks.get_task(task_name, self.args)
         dataset = task.get_dataset()
         # if args.limit is None, use all samples
@@ -56,13 +54,12 @@ class Evaluator:
                 solutions = [[ref] for ref in references]
             return solutions, references
 
-        generations = []  # list[list[str | None]] (list of a list of generations)
-        # Note (Max): when passing an intermediate list of generations, the len would be the same as n_tasks
-        # so need to subset by [gen for gen in intermediate_generations if gen]
+        generations = []  # list[list[str | None] | None]
         if intermediate_generations:
             generations = [gen for gen in intermediate_generations if gen]
+            n_tasks -= len(generations)
         intermediate_save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}_intermediate.json"
-        curr_sample_idx = len(generations)
+        curr_sample_idx = len(generations) - 1
 
         new_generations = parallel_generations(
             task,
@@ -78,7 +75,6 @@ class Evaluator:
         )
         generations.extend(new_generations)
 
-
         if len(generations[0]) > self.args.n_samples:
             generations = [l[: self.args.n_samples] for l in generations]
             warnings.warn(
@@ -86,17 +82,17 @@ class Evaluator:
             )
         return generations, references
 
-    def evaluate(self, task_name):  # TODO (Max): pass intermediate generations file here
+    def evaluate(self, task_name, intermediate_generations):
         task = tasks.get_task(task_name, self.args)
         if task.requires_execution and not self.allow_code_execution:
             raise ValueError(_WARNING)
 
-        generations, references = self.generate_text(task_name)
+        generations, references = self.generate_text(task_name, intermediate_generations)
 
         if self.accelerator.is_main_process:
             if not self.args.load_generations_path:
                 save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}.json"
-                self.save_json_files(self.args, generations, references, save_generations_path, f"references_{task_name}.json")
+                self.save_json_files(generations, references, save_generations_path, f"references_{task_name}.json")
 
             # make sure tokenizer plays nice with multiprocessing
             os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -88,6 +88,7 @@ class Evaluator:
         intermediate_save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}-intermediate.json"
 
         for iter, data_chunk in enumerate(dataset_chunks):
+            curr_sample_idx = len(generations)  
             generation_chunk = parallel_generations(
                 task,
                 Dataset.from_dict(data_chunk),
@@ -97,6 +98,7 @@ class Evaluator:
                 n_tasks=n_tasks,
                 args=self.args,
                 curr_iter=iter,  # Note: this is because we manually change limit_start to 0 if curr_iter > 0
+                curr_sample_idx=curr_sample_idx,  # curr_sample_idx will be used in `complete_code` so we don't mess up indexing during post-process
             )
             generations.extend(generation_chunk)
 

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -72,10 +72,10 @@ class Evaluator:
             self.model,
             self.tokenizer,
             n_tasks=n_tasks,
+            args=self.args,
             curr_sample_idx=curr_sample_idx,  # curr_sample_idx will added to limit_start to fix indexing
             save_every_k_samples=self.args.save_every_k_samples,
             intermediate_save_generations_path=intermediate_save_generations_path,
-            args=self.args,
         )
         generations.extend(new_generations)
 

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -85,7 +85,7 @@ class Evaluator:
         chunk_size = self.args.save_every_k_samples if self.args.save_every_k_samples >= 1 else len(references)
         dataset_chunks = chunk_list(dataset, chunk_size)
         
-        intermediate_save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}-intermediate.json"
+        intermediate_save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}_intermediate.json"
 
         for iter, data_chunk in enumerate(dataset_chunks):
             curr_sample_idx = len(generations)  
@@ -108,7 +108,7 @@ class Evaluator:
                     generations,
                     references[:len(generations)],
                     intermediate_save_generations_path,
-                    "references-intermediate.json"
+                    f"references_{task_name}_intermediate.json"
                 )
 
         if len(generations[0]) > self.args.n_samples:
@@ -127,7 +127,8 @@ class Evaluator:
 
         if self.accelerator.is_main_process:
             if not self.args.load_generations_path:
-                self.save_json_files(generations, references, self.args.save_generations_path, "references.json")
+                save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}.json"
+                self.save_json_files(generations, references, save_generations_path, f"references_{task_name}.json")
 
             # make sure tokenizer plays nice with multiprocessing
             os.environ["TOKENIZERS_PARALLELISM"] = "false"

--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -45,6 +45,10 @@ class Evaluator:
         dataset = task.get_dataset()
         # if args.limit is None, use all samples
         n_tasks = self.args.limit if self.args.limit else len(dataset)
+        # when args.limit is None
+        # adjust n_tasks by args.limit_start to prevent out of bounds issues 
+        if not self.args.limit:
+            n_tasks -= self.args.limit_start
         references = [task.get_reference(dataset[i]) for i in range(self.args.limit_start, self.args.limit_start+n_tasks)]
 
         if self.args.check_references:
@@ -59,7 +63,7 @@ class Evaluator:
             generations = [gen for gen in intermediate_generations if gen]
             n_tasks -= len(generations)
         intermediate_save_generations_path = f"{os.path.splitext(self.args.save_generations_path)[0]}_{task_name}_intermediate.json"
-        curr_sample_idx = len(generations) - 1
+        curr_sample_idx = len(generations)
 
         new_generations = parallel_generations(
             task,

--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -37,7 +37,18 @@ class TooLongFunctionCriteria(StoppingCriteria):
         return input_ids.shape[1] > int(self.input_length * self.multiplier)
         
 
-def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, args, curr_sample_idx, save_every_k_samples, intermediate_save_generations_path):
+def parallel_generations(
+        task,
+        dataset,
+        accelerator,
+        model,
+        tokenizer,
+        n_tasks,
+        curr_sample_idx,
+        save_every_k_samples,
+        intermediate_save_generations_path,
+        args,
+):
     if args.load_generations_path:
         # load generated code
         with open(args.load_generations_path) as fp:

--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -1,7 +1,7 @@
 import json
 from math import ceil
 
-from typing import Optional
+from typing import List, Optional
 
 from accelerate.utils import set_seed
 from torch.utils.data.dataloader import DataLoader
@@ -49,6 +49,7 @@ def parallel_generations(
         args,
         curr_sample_idx: int = 0,
         save_every_k_tasks: int = -1,
+        intermediate_generations: Optional[List[Optional[List[Optional[str]]]]] = None,
         intermediate_save_generations_path: Optional[str] = None,
 ):
     if args.load_generations_path:
@@ -151,6 +152,7 @@ def parallel_generations(
         postprocess=args.postprocess,
         is_wrapped=is_loaded_in_8bit or is_loaded_in_4bit,
         save_every_k_tasks=save_every_k_tasks,
+        intermediate_generations=intermediate_generations,
         intermediate_save_generations_path=intermediate_save_generations_path,
         **gen_kwargs,
     )

--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -48,7 +48,7 @@ def parallel_generations(
         n_tasks,
         args,
         curr_sample_idx: int = 0,
-        save_every_k_samples: int = -1,
+        save_every_k_tasks: int = -1,
         intermediate_save_generations_path: Optional[str] = None,
 ):
     if args.load_generations_path:
@@ -150,7 +150,7 @@ def parallel_generations(
         instruction_tokens=instruction_tokens,
         postprocess=args.postprocess,
         is_wrapped=is_loaded_in_8bit or is_loaded_in_4bit,
-        save_every_k_samples=save_every_k_samples,
+        save_every_k_tasks=save_every_k_tasks,
         intermediate_save_generations_path=intermediate_save_generations_path,
         **gen_kwargs,
     )

--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -37,7 +37,7 @@ class TooLongFunctionCriteria(StoppingCriteria):
         return input_ids.shape[1] > int(self.input_length * self.multiplier)
         
 
-def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, args, curr_iter):
+def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, args, curr_iter, curr_sample_idx):
     if args.load_generations_path:
         # load generated code
         with open(args.load_generations_path) as fp:
@@ -131,7 +131,7 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         tokenizer,
         ds_loader,
         n_tasks=n_tasks,
-        limit_start=args.limit_start if curr_iter == 0 else 0,
+        limit_start=args.limit_start + curr_sample_idx,
         batch_size=args.batch_size,
         prefix=args.prefix,
         instruction_tokens=instruction_tokens,

--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -1,6 +1,8 @@
 import json
 from math import ceil
 
+from typing import Optional
+
 from accelerate.utils import set_seed
 from torch.utils.data.dataloader import DataLoader
 from transformers import StoppingCriteria, StoppingCriteriaList
@@ -44,10 +46,10 @@ def parallel_generations(
         model,
         tokenizer,
         n_tasks,
-        curr_sample_idx,
-        save_every_k_samples,
-        intermediate_save_generations_path,
         args,
+        curr_sample_idx: int = 0,
+        save_every_k_samples: int = -1,
+        intermediate_save_generations_path: Optional[str] = None,
 ):
     if args.load_generations_path:
         # load generated code

--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -37,7 +37,7 @@ class TooLongFunctionCriteria(StoppingCriteria):
         return input_ids.shape[1] > int(self.input_length * self.multiplier)
         
 
-def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, args):
+def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, args, curr_iter):
     if args.load_generations_path:
         # load generated code
         with open(args.load_generations_path) as fp:
@@ -100,7 +100,7 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         tokenizer,
         num_devices=accelerator.state.num_processes,
         max_length=args.max_length_generation,
-        limit_start=args.limit_start,
+        limit_start=args.limit_start if curr_iter == 0 else 0,
         n_tasks=n_tasks,
         n_copies=n_copies,
         prefix=args.prefix,
@@ -131,7 +131,7 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         tokenizer,
         ds_loader,
         n_tasks=n_tasks,
-        limit_start=args.limit_start,
+        limit_start=args.limit_start if curr_iter == 0 else 0,
         batch_size=args.batch_size,
         prefix=args.prefix,
         instruction_tokens=instruction_tokens,

--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -37,7 +37,7 @@ class TooLongFunctionCriteria(StoppingCriteria):
         return input_ids.shape[1] > int(self.input_length * self.multiplier)
         
 
-def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, args, curr_iter, curr_sample_idx):
+def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, args, curr_sample_idx, save_every_k_samples, intermediate_save_generations_path):
     if args.load_generations_path:
         # load generated code
         with open(args.load_generations_path) as fp:
@@ -100,7 +100,7 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         tokenizer,
         num_devices=accelerator.state.num_processes,
         max_length=args.max_length_generation,
-        limit_start=args.limit_start if curr_iter == 0 else 0,
+        limit_start=args.limit_start + curr_sample_idx,
         n_tasks=n_tasks,
         n_copies=n_copies,
         prefix=args.prefix,
@@ -137,6 +137,8 @@ def parallel_generations(task, dataset, accelerator, model, tokenizer, n_tasks, 
         instruction_tokens=instruction_tokens,
         postprocess=args.postprocess,
         is_wrapped=is_loaded_in_8bit or is_loaded_in_4bit,
+        save_every_k_samples=save_every_k_samples,
+        intermediate_save_generations_path=intermediate_save_generations_path,
         **gen_kwargs,
     )
     return generations

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -355,7 +355,8 @@ def complete_code(
         gen_token_dict,
     )
 
-    return intermediate_generations.extend(code_gens)
+    intermediate_generations.extend(code_gens)
+    return intermediate_generations
 
 
 def update_code_gens(

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -235,6 +235,7 @@ def complete_code(
     postprocess=True,
     is_wrapped=False,
     save_every_k_tasks: int = -1,
+    intermediate_generations: Optional[List[Optional[List[Optional[str]]]]] = None,
     intermediate_save_generations_path: Optional[str] = None,
     **gen_kwargs,
 ):
@@ -246,6 +247,7 @@ def complete_code(
     # keep track of the list of generated codes
     # where len(code_gens) = n_tasks and len(code_gens[0]) = number of generated code samples
     code_gens: List[List[Optional[str]]] = [[] for _ in range(n_tasks)]
+    intermediate_generations = [] if not intermediate_generations else intermediate_generations
     gen_token_dict = defaultdict(list)  # dict of list of generated tokens
     for step, batch in tqdm(
         enumerate(dataloader),
@@ -332,7 +334,8 @@ def complete_code(
                     gen_token_dict,
                 )
                 with open(intermediate_save_generations_path, "w") as fp:
-                    json.dump(code_gens, fp)
+                    intermediate_generations.extend(code_gens)
+                    json.dump(intermediate_generations, fp)
                     print(
                         f"intermediate generations were saved at {intermediate_save_generations_path}"
                     )

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -248,7 +248,7 @@ def complete_code(
     # keep track of the list of generated codes
     # where len(code_gens) = n_tasks and len(code_gens[0]) = number of generated code samples
     code_gens: List[List[Optional[str]]] = [[] for _ in range(n_tasks)]
-    intermediate_generations = [] if not intermediate_generations else intermediate_generations
+    generations = [] if not intermediate_generations else intermediate_generations
     gen_token_dict = defaultdict(list)  # dict of list of generated tokens
     for step, batch in tqdm(
         enumerate(dataloader),
@@ -335,7 +335,7 @@ def complete_code(
                     gen_token_dict,
                 )
                 with open(intermediate_save_generations_path, "w") as fp:
-                    intermediate_save_generations = deepcopy(intermediate_generations)
+                    intermediate_save_generations = deepcopy(generations)
                     intermediate_save_generations.extend(code_gens)
                     json.dump(intermediate_save_generations, fp)
                     print(
@@ -355,8 +355,8 @@ def complete_code(
         gen_token_dict,
     )
 
-    intermediate_generations.extend(code_gens)
-    return intermediate_generations
+    generations.extend(code_gens)
+    return generations
 
 
 def update_code_gens(

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -3,7 +3,6 @@ import math
 import re
 import warnings
 from collections import defaultdict
-from copy import deepcopy
 from typing import List, Optional
 
 import torch
@@ -335,9 +334,7 @@ def complete_code(
                     gen_token_dict,
                 )
                 with open(intermediate_save_generations_path, "w") as fp:
-                    intermediate_save_generations = deepcopy(generations)
-                    intermediate_save_generations.extend(code_gens)
-                    json.dump(intermediate_save_generations, fp)
+                    json.dump(generations + code_gens, fp)
                     print(
                         f"intermediate generations were saved at {intermediate_save_generations_path}"
                     )

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -1,6 +1,9 @@
+import json
 import math
+import re
 import warnings
 from collections import defaultdict
+from typing import List, Optional
 
 import torch
 from torch.utils.data import IterableDataset
@@ -49,7 +52,7 @@ class TokenizedDataset(IterableDataset):
         prompts_encoder = []
         infill = []
         instruction = []
-        for sample in range(self.limit_start, self.limit_start+self.n_tasks):
+        for sample in range(self.limit_start, self.limit_start + self.n_tasks):
             prompt_contents = self.task.get_prompt(self.dataset[sample])
             if isinstance(prompt_contents, str):
                 # Normal code completion mode
@@ -111,8 +114,6 @@ class TokenizedDataset(IterableDataset):
                 return_token_type_ids=return_token_type_ids,
             )
 
-
-
         if self.n_copies == 1 and self.n_tasks % self.num_devices != 0:
             self.n_copies = 2
             warnings.warn(
@@ -127,7 +128,9 @@ class TokenizedDataset(IterableDataset):
                         "ids_encoder": outputs_encoder.input_ids[sample],
                         "task_id": sample,
                         "input_len": outputs.attention_mask[sample].sum(),
-                        "input_len_encoder": outputs_encoder.attention_mask[sample].sum(),
+                        "input_len_encoder": outputs_encoder.attention_mask[
+                            sample
+                        ].sum(),
                     }
                 else:
                     yield {
@@ -231,6 +234,8 @@ def complete_code(
     instruction_tokens=None,
     postprocess=True,
     is_wrapped=False,
+    save_every_k_samples: int = -1,
+    intermediate_save_generations_path: Optional[str] = None,
     **gen_kwargs,
 ):
     """Generate multiple codes for each task in the dataset using multiple GPUs with accelerate.
@@ -238,7 +243,9 @@ def complete_code(
     [p_0_0, p_0_1, ..., p_0_nc-1, p_1_0, ..., p_nt-1_nc-1] where nc is the number of copies of the prompt,
     and nt is the number of tasks. nc is such that num_samples(for each task)= nc * batch_size
     """
-
+    # keep track of the list of generated codes
+    # where len(code_gens) = n_tasks and len(code_gens[0]) = number of generated code samples
+    code_gens: List[List[Optional[str]]] = [[] for _ in range(n_tasks)]
     gen_token_dict = defaultdict(list)  # dict of list of generated tokens
     for step, batch in tqdm(
         enumerate(dataloader),
@@ -251,12 +258,14 @@ def complete_code(
                 # Set the start_length after which to check for stopping to be the longest input ignoring padding
                 max_len = batch["input_len"].max().item()
                 if "ids_encoder" in batch:
-                    max_len += 1 # Add 1 for decoder_start_token_id
+                    max_len += 1  # Add 1 for decoder_start_token_id
                 gen_kwargs["stopping_criteria"][0].start_length = max_len
             if hasattr(task, "max_length_multiplier") and task.max_length_multiplier:
                 idx = 1 if task.stop_words else 0
-                gen_kwargs["stopping_criteria"][idx].input_length = batch["input_len"].max().item()                
-            
+                gen_kwargs["stopping_criteria"][idx].input_length = (
+                    batch["input_len"].max().item()
+                )
+
             inputs = batch["ids"][:, : batch["input_len"]]
             if "ids_encoder" in batch:
                 if is_wrapped:
@@ -306,7 +315,57 @@ def complete_code(
             for sample, generated_tokens in zip(generated_tasks, generated_tokens):
                 gen_token_dict[sample].append(generated_tokens)
 
-    code_gens = [[] for _ in range(n_tasks)]
+            if save_every_k_samples >= 1 and step % save_every_k_samples == 0:
+                # Note (Max):
+                # This should be fine since we iterate over each task at a time
+                # so all generations per task would be complete before saving
+                if not intermediate_save_generations_path:
+                    raise ValueError(
+                        "intermediate_save_generations_path cannot be empty!"
+                    )
+
+                code_gens = update_code_gens(
+                    task,
+                    tokenizer,
+                    limit_start,
+                    prefix,
+                    instruction_tokens,
+                    postprocess,
+                    code_gens,
+                    gen_token_dict,
+                )
+                with open(intermediate_save_generations_path, "w") as fp:
+                    json.dump(code_gens, fp)
+                    print(
+                        f"intermediate generations were saved at {intermediate_save_generations_path}"
+                    )
+                # reset gen_token_dict
+                gen_token_dict = defaultdict(list)
+
+    code_gens = update_code_gens(
+        task,
+        tokenizer,
+        limit_start,
+        prefix,
+        instruction_tokens,
+        postprocess,
+        code_gens,
+        gen_token_dict,
+    )
+
+    return code_gens
+
+
+def update_code_gens(
+    task,
+    tokenizer,
+    limit_start,
+    prefix,
+    instruction_tokens,
+    postprocess,
+    code_gens,
+    gen_token_dict,
+):
     for sample, generated_tokens in gen_token_dict.items():
         for s in generated_tokens:
             if INFILL_MODE or tokenizer.eos_token in task.stop_words:
@@ -315,7 +374,7 @@ def complete_code(
                 # Treat eos token as a regular stop word not removing it from the output
                 # If it's removed it may have the effect of removing it in the middle of a
                 # longer generation in case a batch size > 1 is used, which will result in
-                # a wrong generation as it won't be used for splitting lateron 
+                # a wrong generation as it won't be used for splitting lateron
                 gen_code = tokenizer.decode(
                     s, skip_special_tokens=False, clean_up_tokenization_spaces=False
                 )
@@ -339,11 +398,6 @@ def complete_code(
                 )
                 code_gens[sample].append(gen_code)
 
-    return code_gens
-
-
-import re
-
 
 def remove_after_return(code):
     """
@@ -361,6 +415,6 @@ def remove_after_return(code):
             and start_match < len(code)
             and code[start_match].strip() != ""
         ):
-            return code[0:start_match]
+            return code[0: start_match]
         end_last_match = end_match
     return code

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -315,10 +315,7 @@ def complete_code(
             for sample, generated_tokens in zip(generated_tasks, generated_tokens):
                 gen_token_dict[sample].append(generated_tokens)
 
-            if save_every_k_samples >= 1 and step % save_every_k_samples == 0:
-                # Note (Max):
-                # This should be fine since we iterate over each task at a time
-                # so all generations per task would be complete before saving
+            if save_every_k_samples >= 1 and (step + 1) % save_every_k_samples == 0:
                 if not intermediate_save_generations_path:
                     raise ValueError(
                         "intermediate_save_generations_path cannot be empty!"
@@ -339,7 +336,7 @@ def complete_code(
                     print(
                         f"intermediate generations were saved at {intermediate_save_generations_path}"
                     )
-                # reset gen_token_dict
+                # reset gen_token_dict - prevent redundant decoding
                 gen_token_dict = defaultdict(list)
 
     code_gens = update_code_gens(
@@ -397,6 +394,7 @@ def update_code_gens(
                     "model output is not postprocessed, this might lower evaluation scores"
                 )
                 code_gens[sample].append(gen_code)
+    return code_gens
 
 
 def remove_after_return(code):

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -234,7 +234,7 @@ def complete_code(
     instruction_tokens=None,
     postprocess=True,
     is_wrapped=False,
-    save_every_k_samples: int = -1,
+    save_every_k_tasks: int = -1,
     intermediate_save_generations_path: Optional[str] = None,
     **gen_kwargs,
 ):
@@ -315,7 +315,7 @@ def complete_code(
             for sample, generated_tokens in zip(generated_tasks, generated_tokens):
                 gen_token_dict[sample].append(generated_tokens)
 
-            if save_every_k_samples >= 1 and (step + 1) % save_every_k_samples == 0:
+            if save_every_k_tasks >= 1 and (step + 1) % save_every_k_tasks == 0:
                 if not intermediate_save_generations_path:
                     raise ValueError(
                         "intermediate_save_generations_path cannot be empty!"

--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -3,6 +3,7 @@ import math
 import re
 import warnings
 from collections import defaultdict
+from copy import deepcopy
 from typing import List, Optional
 
 import torch
@@ -334,8 +335,9 @@ def complete_code(
                     gen_token_dict,
                 )
                 with open(intermediate_save_generations_path, "w") as fp:
-                    intermediate_generations.extend(code_gens)
-                    json.dump(intermediate_generations, fp)
+                    intermediate_save_generations = deepcopy(intermediate_generations)
+                    intermediate_save_generations.extend(code_gens)
+                    json.dump(intermediate_save_generations, fp)
                     print(
                         f"intermediate generations were saved at {intermediate_save_generations_path}"
                     )
@@ -353,7 +355,7 @@ def complete_code(
         gen_token_dict,
     )
 
-    return code_gens
+    return intermediate_generations.extend(code_gens)
 
 
 def update_code_gens(

--- a/main.py
+++ b/main.py
@@ -121,6 +121,12 @@ def parse_args():
         help="Optional offset to start from when limiting the number of samples",
     )
     parser.add_argument(
+        "--save_every_k_samples",
+        type=int,
+        default=-1,
+        help="Optional saving after every k samples",
+    )
+    parser.add_argument(
         "--postprocess",
         action="store_false",
         help="Postprocess model outputs before execution, always on except during generation tests",

--- a/main.py
+++ b/main.py
@@ -122,10 +122,10 @@ def parse_args():
         help="Optional offset to start from when limiting the number of samples",
     )
     parser.add_argument(
-        "--save_every_k_samples",
+        "--save_every_k_tasks",
         type=int,
         default=-1,
-        help="Optional saving after every k samples",
+        help="Optional saving after every k tasks",
     )
     parser.add_argument(
         "--postprocess",

--- a/main.py
+++ b/main.py
@@ -360,7 +360,9 @@ def main():
             if args.generation_only:
                 if accelerator.is_main_process:
                     print("generation mode only")
-                generations, references = evaluator.generate_text(task, intermediate_generations)  # TODO (Max): pass intermediate generations file here
+                generations, references = evaluator.generate_text(
+                    task, intermediate_generations=intermediate_generations
+                )
                 if accelerator.is_main_process:
                     save_generations_path = f"{os.path.splitext(args.save_generations_path)[0]}_{task}.json"
                     save_references_path = f"references_{task}.json"
@@ -371,7 +373,9 @@ def main():
                         save_references_path,
                     )
             else:
-                results[task] = evaluator.evaluate(task, intermediate_generations)  # TODO (Max): pass intermediate generations file here
+                results[task] = evaluator.evaluate(
+                    task, intermediate_generations=intermediate_generations
+                )
 
     # Save all args to config
     results["config"] = vars(args)

--- a/main.py
+++ b/main.py
@@ -337,6 +337,7 @@ def main():
                     print("generation mode only")
                 generations, references = evaluator.generate_text(task)
                 if accelerator.is_main_process:
+                    # TODO (Max): refactor this with evaluator.save_json_files()?
                     with open(args.save_generations_path, "w") as fp:
                         json.dump(generations, fp)
                         print(f"generations were saved at {args.save_generations_path}")

--- a/main.py
+++ b/main.py
@@ -3,8 +3,6 @@ import fnmatch
 import json
 import warnings
 
-from typing import List, Optional
-
 import datasets
 import torch
 import transformers

--- a/tests/test_generation_evaluation.py
+++ b/tests/test_generation_evaluation.py
@@ -81,7 +81,7 @@ model, tokenizer, accelerator = setup()
 
 def test_generation():
     args.generation_only = True
-    args.save_every_k_samples = -1
+    args.save_every_k_tasks = -1
     evaluator = Evaluator(accelerator, model, tokenizer, args)
     for task in GEN_TASKS:
         print(f"testing task {task}")
@@ -95,7 +95,7 @@ def test_generation():
 def test_evaluation():
     # TODO add scores for each task
     args.n_samples = 2
-    args.save_every_k_samples = -1
+    args.save_every_k_tasks = -1
     for task in EVAL_TASKS:
         print(f"testing task {task}")
         # path to generation examples to evaluate

--- a/tests/test_generation_evaluation.py
+++ b/tests/test_generation_evaluation.py
@@ -81,6 +81,7 @@ model, tokenizer, accelerator = setup()
 
 def test_generation():
     args.generation_only = True
+    args.save_every_k_samples = -1
     evaluator = Evaluator(accelerator, model, tokenizer, args)
     for task in GEN_TASKS:
         print(f"testing task {task}")
@@ -94,6 +95,7 @@ def test_generation():
 def test_evaluation():
     # TODO add scores for each task
     args.n_samples = 2
+    args.save_every_k_samples = -1
     for task in EVAL_TASKS:
         print(f"testing task {task}")
         # path to generation examples to evaluate


### PR DESCRIPTION
  1. append `task_name` for multiple tasks
  2. fix `n_tasks` logic from dataset index out of bounds

Next 2 changes related to #58 
  4. save intermediate generations with `--save_every_k_samples` 
  5. resume generation from intermediate generations with `--load_generations_intermediate_paths`

Tested with HumanEval with saving every 50 samples + loading from intermediate generations: 
```
len(intermediate_generations) = 150
should be generating 14 new samples for new_generations
curr_sample_idx = 150
number of problems for this task is 14
len(dataloader)= 14
len(code_gens) = 14

len(new_generations) = 14
len(generations) after concatenating = 164
```
Verified:
- loading form intermediate generations generates same output as with `--limit_start 150` on HumanEval
- Saved generations match final generations
- Eval metrics unchanged

5. (minor) add some typing + linting
