### PR TITLE
fix starcoder fim constructor

### DIFF
--- a/bigcode_eval/tasks/santacoder_fim.py
+++ b/bigcode_eval/tasks/santacoder_fim.py
@@ -59,11 +59,12 @@ class SantaCoderFIM(Task):
         fim_prefix: str = "<fim-prefix>",
         fim_middle: str = "<fim-middle>",
         fim_suffix: str = "<fim-suffix>",
+        stop_words: List[str] = ["<|endoftext|>", "<|filename|>"],
+        requires_execution: bool = False
     ):
-        stop_words = ["<|endoftext|>", "<|filename|>"]
         super().__init__(
             stop_words=stop_words,
-            requires_execution=False,
+            requires_execution=requires_execution,
         )
         self.fim_prefix = fim_prefix
         self.fim_middle = fim_middle


### PR DESCRIPTION
Small fix when calling `StarCoderFIM` constructor because certain kwargs weren't a part of `SantaCoderFIM`