### PR TITLE
Pass trust_remote_code to load_dataset

### DIFF
--- a/bigcode_eval/base.py
+++ b/bigcode_eval/base.py
@@ -15,17 +15,20 @@ class Task(ABC):
     # The name of a subset within `DATASET_PATH`.
     DATASET_NAME: str = None
 
-    def __init__(self, stop_words=None, requires_execution=True):
+    def __init__(self, stop_words=None, requires_execution=True, trust_remote_code=False):
         """
         :param stop_words: list
             list of stop words if the generation uses a stopping criteria during generation
         :param requires_execution: bool
             wheter the task requires code execution during evaluation or not
+        :param trust_remote_code: bool
+            whether loading the datasets requires remote code execution or not
         """
         self.stop_words = stop_words
         self.requires_execution = requires_execution
+        self.trust_remote_code = trust_remote_code
         try:
-            self.dataset = load_dataset(path=self.DATASET_PATH, name=self.DATASET_NAME)
+            self.dataset = load_dataset(path=self.DATASET_PATH, name=self.DATASET_NAME, trust_remote_code=self.trust_remote_code)
         except Exception as e:
             warn(
                 f"Loading the dataset failed with {str(e)}. This task will use a locally downloaded dataset, not from the HF hub."

--- a/bigcode_eval/tasks/__init__.py
+++ b/bigcode_eval/tasks/__init__.py
@@ -38,6 +38,8 @@ def get_task(task_name, args=None):
             kwargs["prompt"] = args.prompt
         if "load_data_path" in inspect.signature(TASK_REGISTRY[task_name]).parameters:
             kwargs["load_data_path"] = args.load_data_path
+        if "trust_remote_code" in inspect.signature(TASK_REGISTRY[task_name]).parameters:
+            kwargs["trust_remote_code"] = args.trust_remote_code
         return TASK_REGISTRY[task_name](**kwargs)
     except KeyError:
         print("Available tasks:")


### PR DESCRIPTION
To address #176 

this solution still requires all tasks that use dataset builder scripts to pass the kwarg to `super()`. 

currently untested.