### PR TITLE
fix apps evaluate error: local variable 'level' referenced before assignment

### DIFF
--- a/bigcode_eval/tasks/apps.py
+++ b/bigcode_eval/tasks/apps.py
@@ -116,8 +116,6 @@ class GeneralAPPS(Task):
             list of str containing refrences (not needed for APPS Task)
         """
         code_metric = load("codeparrot/apps_metric")
-        if level is None:
-            level = self.DATASET_NAME
         results = code_metric.compute(
             predictions=generations, k_list=self.k_list, level=self.DATASET_NAME
         )


### PR DESCRIPTION
when I evaluate model on apps, meet below error:
```
Traceback (most recent call last):
  File "/kaggle/working/bigcode-evaluation-harness/main.py", line 412, in <module>
    main()
  File "/kaggle/working/bigcode-evaluation-harness/main.py", line 396, in main
    results[task] = evaluator.evaluate(
  File "/kaggle/working/bigcode-evaluation-harness/bigcode_eval/evaluator.py", line 107, in evaluate
    results = task.process_results(generations, references)
  File "/kaggle/working/bigcode-evaluation-harness/bigcode_eval/tasks/apps.py", line 119, in process_results
    if level is None:
UnboundLocalError: local variable 'level' referenced before assignment
```
