### PR TITLE
Ensure generations get saved in generation_only mode

### DIFF
--- a/bigcode_eval/evaluator.py
+++ b/bigcode_eval/evaluator.py
@@ -114,7 +114,7 @@ class Evaluator:
         save_generations_path: str,
         save_references_path: str,
     ) -> None:
-        if self.args.save_generations:
+        if self.args.save_generations or self.args.generation_only:
             with open(save_generations_path, "w") as fp:
                 json.dump(generations, fp)
                 print(f"generations were saved at {save_generations_path}")


### PR DESCRIPTION
as discussed in https://github.com/bigcode-project/bigcode-evaluation-harness/pull/204#issuecomment-2022944059

not tested