### PR TITLE
fix: Multiple-E dataset fix go_test.go path for test execution

### DIFF
--- a/bigcode_eval/tasks/custom_metrics/multiple_metrics/containerized_eval.py
+++ b/bigcode_eval/tasks/custom_metrics/multiple_metrics/containerized_eval.py
@@ -36,6 +36,7 @@ EVALUATORS = {
     "jl": (eval_julia.eval_script, ".jl"),
     "ts": (eval_ts.eval_script, ".ts"),
     "go": (eval_go.eval_script, ".go"),
+    "go_test.go": (eval_go.eval_script, "_test.go"),
     "pl": (eval_pl.eval_script, ".pl"),
     "sh": (eval_sh.eval_script, ".sh"),
     "scala": (eval_scala.eval_script, ".scala"),

--- a/bigcode_eval/tasks/multiple.py
+++ b/bigcode_eval/tasks/multiple.py
@@ -138,7 +138,7 @@ class GeneralMultiPLE(Task):
         """
         # get prompts and problem names
         prompts_names = [
-            {"prompt": doc["prompt"], "name": doc["name"]}
+            {"prompt": doc["prompt"], "name": doc["name"], "lang": doc["language"]}
             for i, doc in enumerate(self.get_dataset())
             if i < len(generations)
         ]
@@ -150,7 +150,7 @@ class GeneralMultiPLE(Task):
         ):
             problem = {
                 "name": prompt_name["name"],
-                "language": self.language,
+                "language": prompt_name["lang"],
                 "prompt": prompt_name["prompt"],
                 "completions": generation,
                 "tests": reference,


### PR DESCRIPTION
Context along with reproducer described in the issue:
Resolves https://github.com/bigcode-project/bigcode-evaluation-harness/issues/224

When I checked the different values of language field can in in the dataset for [different languages](https://github.com/bigcode-project/bigcode-evaluation-harness/blob/main/bigcode_eval/tasks/multiple.py#L37) supported in the`multiple.py`, seems like all of them have the same name except `go` (Adding the repro and screenshot below for this statement).

```
LANGUAGES = [ "py", "sh", "cpp", "cs", "d", "go", "java", "js", "jl", "lua", "pl", "php", "r", "rkt", "rb", "rs", "scala", "swift", "ts"]
for lang in LANGUAGES:
    data = load_dataset('nuprl/MultiPL-E', f'humaneval-{lang}', split='test', revision="d23b094346c5dbda1080a74bb2a24c18adbf7409")
    print(f"languages in multiple-E for {lang}: {set([dt['language'] for dt in data])}")
```

<img width="1166" alt="image" src="https://github.com/bigcode-project/bigcode-evaluation-harness/assets/20701220/671782b8-c7d7-45a4-af84-9d08fe2710ba">

I tried to track the flow of problem['language'] field which I am changing in the PR to make sure it doesn't affect any other language, it seems like this field is only [used in the containerized_eval.py to decide the evaluation script](https://github.com/bigcode-project/bigcode-evaluation-harness/blob/main/bigcode_eval/tasks/custom_metrics/multiple_metrics/containerized_eval.py#L46) to execute and the file extension, and shouldn't affect other language.
I guess the additional fields and seperate handling of the go_test.go was done for different dataset revisions ?

Please let me know if the flow looks good.

Thanks !!



