### PR TITLE
Add package name and enforce python version in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ ds1000_requirements = [
 
 setup(
     name="bigcode_eval",
-    python_requires='>=3.8',
+    python_requires='>=3.7',
     description="A framework for the evaluation of autoregressive code generation language models.",
     long_description=readme,
     license="Apache 2.0",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ ds1000_requirements = [
 ]
 
 setup(
+    name="bigcode_eval",
+    python_requires='>=3.8',
     description="A framework for the evaluation of autoregressive code generation language models.",
     long_description=readme,
     license="Apache 2.0",


### PR DESCRIPTION
No package name is specified in the `setup.py` file, which yields errors when trying to install the `bigcode-eval` package via pip. Please this issue for details: https://github.com/bigcode-project/bigcode-evaluation-harness/issues/231