### PR TITLE
fix: rust timeout exception

### DIFF
--- a/bigcode_eval/tasks/humanevalpack.py
+++ b/bigcode_eval/tasks/humanevalpack.py
@@ -352,7 +352,7 @@ class HumanEvalPackGenerative(HumanEvalPack):
         :param references: list(str)
             list of str containing refrences
         """
-        code_metric = load("Muennighoff/code_eval_octopack")
+        code_metric = load("jiiiiin/code_eval_octopack")
         timeout = LANGUAGE_TO_TIMEOUT[self.DATASET_NAME]
         num_workers = LANGUAGE_TO_NUM_WORKERS[self.DATASET_NAME]
         language = self.DATASET_NAME if self.DATASET_NAME != "js" else "javascript"


### PR DESCRIPTION
- While evaluating the humanevalpack-rust, it was unable to proceed with the evaluation due to a timeout error from subprocess execution. 
- This PR applies the try-except statement to handle subprocess.TimeoutExpired in the rust execution function.
If you think it would be better to commit this to [code_eval_octopack](https://huggingface.co/spaces/Muennighoff/code_eval_octopack/blob/main/execute.py), you can close this PR :)
