### PR TITLE
Fix Max New Tokens in HF's Generation Config

### DIFF
--- a/bigcode_eval/generation.py
+++ b/bigcode_eval/generation.py
@@ -70,7 +70,7 @@ def parallel_generations(
         "temperature": args.temperature,
         "top_p": args.top_p,
         "top_k": args.top_k,
-        "max_length": args.max_length_generation,
+        "max_new_tokens": args.max_length_generation,
     }
     stopping_criteria = []
     # The input_length / start_length set to 0 for now will be adjusted later


### PR DESCRIPTION
HuggingFace's `max_length` configuration corresponds to the total length of the prompt and the generated output, while `max_new_tokens` corresponds to the length of generated output only.

Using `args.max_length_generation` to set `max_new_tokens` fixed runtime errors for me.  Using `args.max_length_generation` to set `max_length` lead to runtime errors because the total length of prompt+generation would exceed the intended value.