### PR TITLE
Downgrade pyext dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ transformers>=4.25.1
 accelerate>=0.13.2
 datasets>=2.6.1
 evaluate>=0.3.0
-pyext==0.7
+pyext==0.5
 mosestokenizer==1.0.0
 huggingface_hub>=0.11.1
 fsspec<2023.10.0


### PR DESCRIPTION
Currently, the `pyext` package dependency is pinned to version `0.7`. However, this yields the following error with Python 3.11 when trying to install `bigcode-eval` package via pip:

```
oargspec = inspect.getargspec
           ^^^^^^^^^^^^^^^^^^
      AttributeError: module 'inspect' has no attribute 'getargspec'. Did you mean: 'getargs'?
```

`pyext==0.7` doesn't look like an official release version (https://pypi.org/project/pyext/#history) and so it doesn't seem like this issue will be fixed any time soon to work with the newer version of Python

So in order to make `bigcode-eval` work with Python 3.11,  this change downgrades the `pyext` package pin to 0.5. Note that there was a PR (https://github.com/bigcode-project/bigcode-evaluation-harness/pull/181) raised to address this issue previously, but not sure why it got closed.