### PR TITLE
Update `fsspec`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ evaluate>=0.3.0
 pyext==0.5
 mosestokenizer==1.0.0
 huggingface_hub>=0.11.1
-fsspec<2023.10.0
+fsspec>=2023.12.2


### PR DESCRIPTION
# What does this PR do?

updates `fsspec` so that users can install lighteval and bigcode eval in the same environment : https://github.com/huggingface/lighteval/blob/7295c78fcb63604cc18c43dd62349a6120ac8600/pyproject.toml#L77

cc @loubnabnl 