### PR TITLE
ibm-watsonx-ai integration

### DIFF
--- a/bigcode_eval/wx_ai.py
+++ b/bigcode_eval/wx_ai.py
@@ -1,0 +1,100 @@
+from argparse import Namespace
+from typing import Any, Iterable, Optional
+
+from datasets import Dataset
+from ibm_watsonx_ai import APIClient
+from ibm_watsonx_ai.foundation_models import ModelInference
+from unitxt.inference import WMLInferenceEngineBase
+
+from bigcode_eval.base import Task
+
+
+class WxInference:
+    def __init__(self):
+        wx_creds = WMLInferenceEngineBase._read_wml_credentials_from_env()
+        WMLInferenceEngineBase._verify_wml_credentials(wx_creds)
+
+        self.client = APIClient(
+            project_id=wx_creds.pop("project_id", None),
+            space_id=wx_creds.pop("space_id", None),
+            credentials=wx_creds,
+        )
+
+    @staticmethod
+    def get_stop_sequences_for_wx(args: Namespace, task: Task) -> Optional[list[str]]:
+        # TODO
+        stop_sequences = []
+
+        if isinstance(task.stop_words, Iterable):
+            stop_sequences.extend(task.stop_words)
+        elif task.stop_words is not None:
+            stop_sequences.append(task.stop_words)
+
+        if args.instruction_tokens:
+            for token in args.instruction_tokens.split(","):
+                if token.strip() != "":
+                    stop_sequences.append(token)
+
+        return stop_sequences if stop_sequences else None
+
+    @staticmethod
+    def prepare_wx_gen_params(args: Namespace) -> dict[str, Any]:
+        # TODO: need more generation params?
+        # TODO: HF also uses more "sophisticated" stop criteria than stop words
+        params = {
+            "decoding_method": "sample" if args.do_sample else "greedy",
+            "temperature": args.temperature,
+            "top_p": args.top_p,
+            "top_k": args.top_k,
+            "max_new_tokens": args.max_length_generation,  # wx only has "max_new_tokens"
+        }
+
+        return params
+
+    def initialize_wx_model(self, model_name: str) -> ModelInference:
+        return ModelInference(
+            model_id=model_name,
+            api_client=self.client,
+        )
+
+    @staticmethod
+    def prepare_inputs(dataset: Dataset, task: Task) -> list[str]:
+        return [
+            task.get_prompt(sample)
+            for sample in dataset
+        ]
+
+    def infer(
+        self,
+        dataset: Dataset,
+        task: Task,
+        args: Namespace,
+        postprocess: bool = True,
+    ) -> list[str]:
+        gen_params = self.prepare_wx_gen_params(args)
+        # gen_params["stop_sequences"] = self.get_stop_sequences_for_wx(
+        #     args, task
+        # )
+
+        model = self.initialize_wx_model(args.model)
+
+        predictions = [
+            result["results"][0]["generated_text"]
+            for result in
+            model.generate(
+                prompt=self.prepare_inputs(dataset, task),
+                params=gen_params,
+            )
+        ]
+
+        if postprocess:
+            predictions = self.postprocess_predictions(predictions, task)
+
+        return predictions
+
+    @staticmethod
+    def postprocess_predictions(predictions: list[str], task: Task) -> list[str]:
+        return [
+            task.postprocess_generation(prediction, idx)
+            for idx, prediction in enumerate(predictions)
+        ]

--- a/main.py
+++ b/main.py
@@ -46,8 +46,9 @@ def parse_args():
     )
     parser.add_argument(
         "--modeltype",
-        default="causal",
-        help="AutoModel to use, it can be causal or seq2seq",
+        default="wx",
+        help="Type of model to use for inference. Can be either any valid watsonx.ai model, "
+             "or HuggingFace AutoModel. In case of the latter, it can be causal or seq2seq.",
     )
     parser.add_argument(
         "--peft_model",
@@ -253,112 +254,115 @@ def main():
             results[task] = evaluator.evaluate(task)
     else:
         # here we generate code and save it (evaluation is optional but True by default)
-        dict_precisions = {
-            "fp32": torch.float32,
-            "fp16": torch.float16,
-            "bf16": torch.bfloat16,
-        }
-        if args.precision not in dict_precisions:
-            raise ValueError(
-                f"Non valid precision {args.precision}, choose from: fp16, fp32, bf16"
-            )
+        model, tokenizer = None, None
 
-        model_kwargs = {
-            "revision": args.revision,
-            "trust_remote_code": args.trust_remote_code,
-            "token": args.use_auth_token,
-        }
-        if args.load_in_8bit:
-            print("Loading model in 8bit")
-            model_kwargs["load_in_8bit"] = args.load_in_8bit
-            model_kwargs["device_map"] = {"": accelerator.process_index}
-        elif args.load_in_4bit:
-            print("Loading model in 4bit")
-            model_kwargs["load_in_4bit"] = args.load_in_4bit
-            model_kwargs["torch_dtype"] = torch.float16
-            model_kwargs["bnb_4bit_compute_dtype"] = torch.float16            
-            model_kwargs["device_map"] = {"": accelerator.process_index}
-        else:
-            print(f"Loading model in {args.precision}")
-            model_kwargs["torch_dtype"] = dict_precisions[args.precision]
+        if args.modeltype != "wx":
+            dict_precisions = {
+                "fp32": torch.float32,
+                "fp16": torch.float16,
+                "bf16": torch.bfloat16,
+            }
+            if args.precision not in dict_precisions:
+                raise ValueError(
+                    f"Non valid precision {args.precision}, choose from: fp16, fp32, bf16"
+                )
 
-            if args.max_memory_per_gpu:
-                if args.max_memory_per_gpu != "auto":
-                    model_kwargs["max_memory"] = get_gpus_max_memory(
-                        args.max_memory_per_gpu, accelerator.num_processes
-                    )
-                    model_kwargs["offload_folder"] = "offload"
-                else:
-                    model_kwargs["device_map"] = "auto"
-                    print("Loading model in auto mode")
-
-        if args.modeltype == "causal":
-            model = AutoModelForCausalLM.from_pretrained(
-                args.model,
-                **model_kwargs,
-            )
-        elif args.modeltype == "seq2seq":
-            warnings.warn(
-                "Seq2Seq models have only been tested for HumanEvalPack & CodeT5+ models."
-            )
-            model = AutoModelForSeq2SeqLM.from_pretrained(
-                args.model,
-                **model_kwargs,
-            )
-        else:
-            raise ValueError(
-                f"Non valid modeltype {args.modeltype}, choose from: causal, seq2seq"
-            )
-
-        if args.peft_model:
-            from peft import PeftModel  # dynamic import to avoid dependency on peft
-
-            model = PeftModel.from_pretrained(model, args.peft_model)
-            print("Loaded PEFT model. Merging...")
-            model.merge_and_unload()
-            print("Merge complete.")
-
-        if args.left_padding:
-            # left padding is required for some models like chatglm3-6b
-            tokenizer = AutoTokenizer.from_pretrained(
-                args.model,
-                revision=args.revision,
-                trust_remote_code=args.trust_remote_code,
-                token=args.use_auth_token,
-                padding_side="left",  
-            )
-        else:
-            # used by default for most models
-            tokenizer = AutoTokenizer.from_pretrained(
-                args.model,
-                revision=args.revision,
-                trust_remote_code=args.trust_remote_code,
-                token=args.use_auth_token,
-                truncation_side="left",
-                padding_side="right",  
-            )
-        if not tokenizer.eos_token:
-            if tokenizer.bos_token:
-                tokenizer.eos_token = tokenizer.bos_token
-                print("bos_token used as eos_token")
+            model_kwargs = {
+                "revision": args.revision,
+                "trust_remote_code": args.trust_remote_code,
+                "token": args.use_auth_token,
+            }
+            if args.load_in_8bit:
+                print("Loading model in 8bit")
+                model_kwargs["load_in_8bit"] = args.load_in_8bit
+                model_kwargs["device_map"] = {"": accelerator.process_index}
+            elif args.load_in_4bit:
+                print("Loading model in 4bit")
+                model_kwargs["load_in_4bit"] = args.load_in_4bit
+                model_kwargs["torch_dtype"] = torch.float16
+                model_kwargs["bnb_4bit_compute_dtype"] = torch.float16
+                model_kwargs["device_map"] = {"": accelerator.process_index}
             else:
-                raise ValueError("No eos_token or bos_token found")
-        try:
-            tokenizer.pad_token = tokenizer.eos_token
+                print(f"Loading model in {args.precision}")
+                model_kwargs["torch_dtype"] = dict_precisions[args.precision]
+
+                if args.max_memory_per_gpu:
+                    if args.max_memory_per_gpu != "auto":
+                        model_kwargs["max_memory"] = get_gpus_max_memory(
+                            args.max_memory_per_gpu, accelerator.num_processes
+                        )
+                        model_kwargs["offload_folder"] = "offload"
+                    else:
+                        model_kwargs["device_map"] = "auto"
+                        print("Loading model in auto mode")
+
+            if args.modeltype == "causal":
+                model = AutoModelForCausalLM.from_pretrained(
+                    args.model,
+                    **model_kwargs,
+                )
+            elif args.modeltype == "seq2seq":
+                warnings.warn(
+                    "Seq2Seq models have only been tested for HumanEvalPack & CodeT5+ models."
+                )
+                model = AutoModelForSeq2SeqLM.from_pretrained(
+                    args.model,
+                    **model_kwargs,
+                )
+            else:
+                raise ValueError(
+                    f"Non valid modeltype {args.modeltype}, choose from: causal, seq2seq"
+                )
+
+            if args.peft_model:
+                from peft import PeftModel  # dynamic import to avoid dependency on peft
+
+                model = PeftModel.from_pretrained(model, args.peft_model)
+                print("Loaded PEFT model. Merging...")
+                model.merge_and_unload()
+                print("Merge complete.")
+
+            if args.left_padding:
+                # left padding is required for some models like chatglm3-6b
+                tokenizer = AutoTokenizer.from_pretrained(
+                    args.model,
+                    revision=args.revision,
+                    trust_remote_code=args.trust_remote_code,
+                    token=args.use_auth_token,
+                    padding_side="left",
+                )
+            else:
+                # used by default for most models
+                tokenizer = AutoTokenizer.from_pretrained(
+                    args.model,
+                    revision=args.revision,
+                    trust_remote_code=args.trust_remote_code,
+                    token=args.use_auth_token,
+                    truncation_side="left",
+                    padding_side="right",
+                )
+            if not tokenizer.eos_token:
+                if tokenizer.bos_token:
+                    tokenizer.eos_token = tokenizer.bos_token
+                    print("bos_token used as eos_token")
+                else:
+                    raise ValueError("No eos_token or bos_token found")
+            try:
+                tokenizer.pad_token = tokenizer.eos_token
             
-        # Some models like CodeGeeX2 have pad_token as a read-only property
-        except AttributeError:
-            print("Not setting pad_token to eos_token")
-            pass
-        WIZARD_LLAMA_MODELS = [
-            "WizardLM/WizardCoder-Python-34B-V1.0",
-            "WizardLM/WizardCoder-34B-V1.0",
-            "WizardLM/WizardCoder-Python-13B-V1.0"
-        ]
-        if args.model in WIZARD_LLAMA_MODELS:
-            tokenizer.bos_token = "<s>"
-            tokenizer.bos_token_id = 1
-            print("Changing bos_token to <s>")
+            # Some models like CodeGeeX2 have pad_token as a read-only property
+            except AttributeError:
+                print("Not setting pad_token to eos_token")
+                pass
+            WIZARD_LLAMA_MODELS = [
+                "WizardLM/WizardCoder-Python-34B-V1.0",
+                "WizardLM/WizardCoder-34B-V1.0",
+                "WizardLM/WizardCoder-Python-13B-V1.0"
+            ]
+            if args.model in WIZARD_LLAMA_MODELS:
+                tokenizer.bos_token = "<s>"
+                tokenizer.bos_token_id = 1
+                print("Changing bos_token to <s>")
 
         evaluator = Evaluator(accelerator, model, tokenizer, args)
 


### PR DESCRIPTION
Only tasks which don't execute any code were tested for now.
Things which still need to be addressed: exact mapping of generation parameters (and possibly support for additional ones), stop sequences and stopping criteria (used for HF models).

Example output after running the following command 
`python main.py --model "ibm/granite-3b-code-instruct" --tasks "conala" --top_k 1` (WML doesn't support `top_k=0` which is default value in bigcode):


```
Evaluating generations...
{
  "conala": {
    "bleu": 1.893454186003354e-08,
    "precisions": [
      0.04590818363273453,
      1.0,
      1.0,
      1.0
    ],
    "brevity_penalty": 4.090555352941771e-08,
    "length_ratio": 0.055518543193426605,
    "translation_length": 500,
    "reference_length": 9006
  },
  "config": {
    "prefix": "",
    "do_sample": true,
    "temperature": 0.2,
    "top_k": 1,
    "top_p": 0.95,
    "n_samples": 1,
    "eos": "<|endoftext|>",
    "seed": 0,
    "model": "ibm/granite-3b-code-instruct",
    "modeltype": "wx",
    "peft_model": null,
    "revision": null,
    "use_auth_token": false,
    "trust_remote_code": false,
    "tasks": "conala",
    "instruction_tokens": null,
    "batch_size": 1,
    "max_length_generation": 512,
    "precision": "fp32",
    "load_in_8bit": false,
    "load_in_4bit": false,
    "left_padding": false,
    "limit": null,
    "limit_start": 0,
    "save_every_k_tasks": -1,
    "postprocess": true,
    "allow_code_execution": false,
    "generation_only": false,
    "load_generations_path": null,
    "load_data_path": null,
    "metric_output_path": "evaluation_results.json",
    "save_generations": false,
    "load_generations_intermediate_paths": null,
    "save_generations_path": "generations.json",
    "save_references": false,
    "save_references_path": "references.json",
    "prompt": "prompt",
    "max_memory_per_gpu": null,
    "check_references": false
  }
}
```
