### PR TITLE
[Pytest] Fix bad import to use relative instead @ module_test

### DIFF
--- a/bigcode_eval/tasks/custom_metrics/multiple_metrics/safe_subprocess/module_test.py
+++ b/bigcode_eval/tasks/custom_metrics/multiple_metrics/safe_subprocess/module_test.py
@@ -1,7 +1,7 @@
 import time
 from pathlib import Path
 
-from safe_subprocess import run
+from . import run
 
 ROOT = Path(__file__).resolve().parent / "evil_programs"
 


### PR DESCRIPTION
This fixes a bad import at module_test

### Steps to reproduce

Clone the main repo
```bash
$ git clone https://github.com/bigcode-project/bigcode-evaluation-harness.git
$ cd bigcode-evaluation-harness/
```

I am using conda envs
```bash
$ conda create -n bc-harness python=3.11
$ conda activate bc-harness
$ pip install -r requirements.txt && pip install pytest
```

Then as suggested by the GUIDE.md we should run `pytest`:
https://github.com/bigcode-project/bigcode-evaluation-harness/blob/6116c6a9a5672c69bd624373cfbc8938b7acc249/docs/guide.md?plain=1#L125-L131

However when running a bad import error triggers:
```
# pytest                                                                                            (bc-harnes) 
============================================= test session starts ==============================================
platform darwin -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0
rootdir: /private/tmp/bigcode-evaluation-harness
collected 3 items / 1 error                                                                                    

==================================================== ERRORS ====================================================
______ ERROR collecting bigcode_eval/tasks/custom_metrics/multiple_metrics/safe_subprocess/module_test.py ______ImportError while importing test module '/private/tmp/bigcode-evaluation-harness/bigcode_eval/tasks/custom_metrics/multiple_metrics/safe_subprocess/module_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/Users/ggcr/miniconda3/envs/bc-harnes/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
bigcode_eval/tasks/custom_metrics/multiple_metrics/safe_subprocess/module_test.py:4: in <module>
    from safe_subprocess import run
E   ModuleNotFoundError: No module named 'safe_subprocess'
=============================================== warnings summary ===============================================bigcode_eval/tasks/humanevalpack.py:179
  /private/tmp/bigcode-evaluation-harness/bigcode_eval/tasks/humanevalpack.py:179: DeprecationWarning: invalid escape sequence '\ '
    stop_words = ["<BEF>", "<MSG>", "<DFF>", "\ No newline at end of file"]

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== short test summary info ============================================ERROR bigcode_eval/tasks/custom_metrics/multiple_metrics/safe_subprocess/module_test.py
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!========================================= 1 warning, 1 error in 24.32s ========================================
```




