### PR TITLE
Missing comma in MultiPL-E languages

### DIFF
--- a/bigcode_eval/tasks/multiple.py
+++ b/bigcode_eval/tasks/multiple.py
@@ -41,7 +41,7 @@ _CITATION = """
 LANGUAGES = [
     "py",
     "sh",
-    "clj"
+    "clj",
     "cpp",
     "cs",
     "d",


### PR DESCRIPTION
Specifying the task as `multiple-cpp` gives an error because of a missing comma in `LANGUAGES` which ends up merging `clj` and `cpp` as a single task `multiple-cljcpp`.