### PR TITLE
use tokenizer.chat_template by default for instruction type tasks

### DIFF
--- a/bigcode_eval/utils.py
+++ b/bigcode_eval/utils.py
@@ -71,9 +71,21 @@ class TokenizedDataset(IterableDataset):
                     # Instruction-tuning mode
                     instruction.append(True)
                     infill.append(False)
-                    prompt = self._make_instruction_prompt(
-                        **prompt_contents, prefix=self.prefix
-                    )
+
+                    if self.tokenizer.chat_template is not None:
+                        prompt = (
+                            self.prefix
+                            + self.tokenizer.apply_chat_template(
+                                [{"role": "user", "content": prompt_contents['instruction']}],
+                                add_generation_prompt=True,
+                                tokenize=False
+                            )
+                            + prompt_contents['context']
+                        )
+                    else:
+                        prompt = self._make_instruction_prompt(
+                            **prompt_contents, prefix=self.prefix
+                        )
             else:
                 raise ValueError(f"Unsupported prompt format: {type(prompt_contents)}")
             prompts.append(prompt)


### PR DESCRIPTION
## Changes
Use `tokenizer.chat_template` (if exists) for instruction type tasks by default.

## Issue Addressed
This address the issue for models such as `google/gemma-2-2b-it`, where the instruction tokens are 

```
--instruction_tokens "<start_of_turn>user\n","<end_of_turn>\n","<start_of_turn>model\n"
```

However, in the current implementation, because of string escaping, the prompt template escapes `\n` to `\\n`, which makes the final template different from the model's actual template. Additionally the current implementation doesn't add `<bos>` for tokenizers that use them by default.

## Notes

Only tested on `instruct-humaneval` for  `google/gemma-2-2b-it` and `meta-llama/Llama-3.2-1B-Instruct` for now.