### PR TITLE
Fix UnboundLocalError in APPS task evaluation

### DIFF
--- a/bigcode_eval/tasks/apps.py
+++ b/bigcode_eval/tasks/apps.py
@@ -116,8 +116,6 @@ class GeneralAPPS(Task):
             list of str containing refrences (not needed for APPS Task)
         """
         code_metric = load("codeparrot/apps_metric")
-        if level is None:
-            level = self.DATASET_NAME
         results = code_metric.compute(
             predictions=generations, k_list=self.k_list, level=self.DATASET_NAME
         )


### PR DESCRIPTION
Removed reference to undefined 'level' variable in the process_results method. The code was attempting to check if 'level' was None before setting it to self.DATASET_NAME, but 'level' wasn't defined in the method scope. Since self.DATASET_NAME is already used correctly in the code_metric.compute() call, the check was unnecessary.